### PR TITLE
Fix Xray WireGuard subscription imports

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 78
-        versionName = "1.4.0"
+        versionName = "1.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/whitedns/vpn/UserSubscriptions.kt
+++ b/app/src/main/java/com/whitedns/vpn/UserSubscriptions.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 
 enum class UserSubscriptionFormat(val wireName: String, val label: String) {
     Mihomo("mihomo", "Mihomo YAML"),
-    Links("links", "VLESS / VMess / Trojan / SS");
+    Links("links", "VLESS / VMess / Trojan / SS / WireGuard");
 
     companion object {
         fun fromWireName(value: String?): UserSubscriptionFormat =
@@ -88,9 +88,93 @@ object JsonSubscriptionImporter {
     }
 
     private fun xrayProxies(configs: JSONArray): List<JSONObject> {
-        return (0 until configs.length()).mapNotNull { index ->
-            configs.optJSONObject(index)?.let { xrayProxy(it, index) }
+        return (0 until configs.length()).flatMap { index ->
+            val config = configs.optJSONObject(index) ?: return@flatMap emptyList()
+            xrayWireGuardProxies(config, index).ifEmpty { listOfNotNull(xrayProxy(config, index)) }
         }
+    }
+
+    private fun xrayWireGuardProxies(config: JSONObject, index: Int): List<JSONObject> {
+        val outbounds = config.optJSONArray("outbounds") ?: return emptyList()
+        val wireGuard = (0 until outbounds.length())
+            .mapNotNull(outbounds::optJSONObject)
+            .filter { it.optString("protocol") == "wireguard" }
+        if (wireGuard.isEmpty()) return emptyList()
+
+        val baseName = config.optString("remarks").ifBlank { "Xray ${index + 1}" }
+        val names = wireGuard.mapIndexed { position, outbound ->
+            if (position == 0) baseName else "$baseName (${outbound.optString("tag").ifBlank { "WireGuard ${position + 1}" }})"
+        }
+        val converted = wireGuard.mapIndexedNotNull { position, outbound ->
+            xrayWireGuardProxy(outbound, names[position])?.let { outbound to it }
+        }
+        val namesByTag = converted.mapNotNull { (outbound, proxy) ->
+            outbound.optString("tag").takeIf(String::isNotBlank)?.let { it to proxy.getString("name") }
+        }.toMap()
+
+        return converted.mapNotNull { (outbound, proxy) ->
+            val dialerTag = outbound.optJSONObject("streamSettings")
+                ?.optJSONObject("sockopt")
+                ?.optString("dialerProxy")
+                .orEmpty()
+            if (dialerTag.isBlank()) return@mapNotNull proxy
+            val dialerName = namesByTag[dialerTag] ?: return@mapNotNull null
+            proxy.put("dialer-proxy", dialerName)
+        }
+    }
+
+    private fun xrayWireGuardProxy(outbound: JSONObject, name: String): JSONObject? {
+        val settings = outbound.optJSONObject("settings") ?: return null
+        val peers = settings.optJSONArray("peers") ?: return null
+        // ponytail: current Xray WARP feeds use one peer; add Mihomo full `peers` syntax if a real multi-peer feed appears.
+        if (peers.length() != 1) return null
+        val peer = peers.optJSONObject(0) ?: return null
+        val (server, port) = wireGuardEndpoint(peer.optString("endpoint")) ?: return null
+        val privateKey = settings.optString("secretKey").takeIf(String::isNotBlank) ?: return null
+        val publicKey = peer.optString("publicKey").takeIf(String::isNotBlank) ?: return null
+        val addresses = settings.optJSONArray("address") ?: return null
+        val localAddresses = (0 until addresses.length())
+            .mapNotNull { addresses.opt(it) as? String }
+            .map { it.substringBefore('/').trim() }
+            .filter(String::isNotBlank)
+        val ipv4 = localAddresses.firstOrNull { ':' !in it } ?: return null
+        val ipv6 = localAddresses.firstOrNull { ':' in it }
+
+        return JSONObject()
+            .put("name", name)
+            .put("type", "wireguard")
+            .put("server", server)
+            .put("port", port)
+            .put("ip", ipv4)
+            .put("ip-version", if (ipv6 == null) "ipv4" else "ipv4-prefer")
+            .put("private-key", privateKey)
+            .put("public-key", publicKey)
+            .put("allowed-ips", peer.optJSONArray("allowedIPs") ?: JSONArray(listOf("0.0.0.0/0", "::/0")))
+            .put("udp", true)
+            .apply {
+                ipv6?.let { put("ipv6", it) }
+                settings.optJSONArray("reserved")?.let { put("reserved", wireGuardReserved(it) ?: return null) }
+                settings.optInt("mtu").takeIf { it > 0 }?.let { put("mtu", it) }
+                peer.optString("preSharedKey").takeIf(String::isNotBlank)?.let { put("pre-shared-key", it) }
+                peer.optInt("keepAlive").takeIf { it > 0 }?.let { put("persistent-keepalive", it) }
+            }
+    }
+
+    private fun wireGuardEndpoint(value: String): Pair<String, Int>? {
+        val endpoint = runCatching { URI("wg://$value") }.getOrNull() ?: return null
+        val server = endpoint.host?.removePrefix("[")?.removeSuffix("]")?.takeIf(String::isNotBlank) ?: return null
+        val port = endpoint.port.takeIf { it in 1..65535 } ?: return null
+        return server to port
+    }
+
+    private fun wireGuardReserved(source: JSONArray): JSONArray? {
+        if (source.length() != 3) return null
+        val values = mutableListOf<Int>()
+        for (index in 0 until source.length()) {
+            val value = (source.opt(index) as? Number)?.toInt()?.takeIf { it in 0..255 } ?: return null
+            values += value
+        }
+        return JSONArray(values)
     }
 
     private fun xrayProxy(config: JSONObject, index: Int): JSONObject? {

--- a/app/src/test/java/com/whitedns/vpn/UserSubscriptionImporterTest.kt
+++ b/app/src/test/java/com/whitedns/vpn/UserSubscriptionImporterTest.kt
@@ -275,6 +275,73 @@ class UserSubscriptionImporterTest {
     }
 
     @Test
+    fun importerNormalizesXrayWireGuardAndChains() {
+        val imported = UserSubscriptionImporter.import(
+            """
+            [
+              {
+                "remarks": "WARP",
+                "outbounds": [{
+                  "tag": "proxy",
+                  "protocol": "wireguard",
+                  "settings": {
+                    "secretKey": "private-one",
+                    "address": ["172.16.0.2/32", "2606:4700:110:8765::2/128"],
+                    "mtu": 1280,
+                    "reserved": [1, 2, 3],
+                    "peers": [{
+                      "endpoint": "engage.example.com:2408",
+                      "publicKey": "public-one",
+                      "keepAlive": 25
+                    }]
+                  }
+                }]
+              },
+              {
+                "remarks": "WoW",
+                "outbounds": [
+                  {
+                    "tag": "chain",
+                    "protocol": "wireguard",
+                    "settings": {
+                      "secretKey": "private-chain",
+                      "address": ["172.16.0.3/32"],
+                      "peers": [{"endpoint": "162.159.192.1:2408", "publicKey": "public-chain"}]
+                    },
+                    "streamSettings": {"sockopt": {"dialerProxy": "proxy"}}
+                  },
+                  {
+                    "tag": "proxy",
+                    "protocol": "wireguard",
+                    "settings": {
+                      "secretKey": "private-base",
+                      "address": ["172.16.0.4/32"],
+                      "peers": [{"endpoint": "engage.example.net:2408", "publicKey": "public-base"}]
+                    }
+                  }
+                ]
+              }
+            ]
+            """.trimIndent(),
+            nowMs = 123L,
+        )
+        val snapshot = MihomoConfigParser.parse(imported.yaml, 123L)
+
+        assertEquals(UserSubscriptionFormat.Links, imported.format)
+        assertEquals(3, imported.connectionCount)
+        assertTrue(snapshot.catalog.profiles.all { it.type == "wireguard" })
+        assertTrue(imported.yaml.contains("private-key: 'private-one'"))
+        assertTrue(imported.yaml.contains("ip: '172.16.0.2'"))
+        assertTrue(imported.yaml.contains("ipv6: '2606:4700:110:8765::2'"))
+        assertTrue(imported.yaml.contains("ip-version: 'ipv4-prefer'"))
+        assertTrue(imported.yaml.contains("ip-version: 'ipv4'"))
+        assertTrue(imported.yaml.contains("allowed-ips: ['0.0.0.0/0', '::/0']"))
+        assertTrue(imported.yaml.contains("reserved: [1, 2, 3]"))
+        assertTrue(imported.yaml.contains("persistent-keepalive: 25"))
+        assertTrue(imported.yaml.contains("dialer-proxy: 'WoW (proxy)'"))
+    }
+
+    @Test
     fun importerSupportsXrayTrojanAndSkipsAggregateConfigs() {
         val imported = UserSubscriptionImporter.import(
             """


### PR DESCRIPTION
## Summary

Adds support for importing Xray JSON subscriptions containing WireGuard/WARP outbounds and converting them into Mihomo-compatible proxies.

## Changes

- Convert Xray WireGuard fields to Mihomo format.
- Support IPv4/IPv6 addresses, MTU, reserved bytes, allowed IPs, pre-shared keys, and keepalive.
- Preserve chained WARP/WoW configurations using `dialer-proxy`.
- Validate endpoints, ports, keys, and reserved-byte values.
- Add regression coverage for direct and chained WireGuard profiles.
- Bump app version to `1.4.1` while keeping `versionCode = 78`.

## Why

The Xray importer previously recognized only VLESS, VMess, and Trojan outbounds. BPB WARP subscriptions therefore produced no supported connections even though the response was valid Xray JSON.

## Validation

- Full `UserSubscriptionImporterTest` suite passes.
- The supplied BPB payload imports successfully as six WireGuard entries.
- Generated BuildConfig reports version `1.4.1`.
- `git diff --check` passes.