### PR TITLE
Release WhiteVPN 1.6.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,8 +79,8 @@ android {
         applicationId = "com.whitedns.vpn"
         minSdk = 26
         targetSdk = 35
-        versionCode = 79
-        versionName = "1.6.4"
+        versionCode = 80
+        versionName = "1.6.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         resourceConfigurations += listOf("en", "fa")

--- a/app/src/main/java/com/whitedns/vpn/MihomoRuntime.kt
+++ b/app/src/main/java/com/whitedns/vpn/MihomoRuntime.kt
@@ -1772,8 +1772,8 @@ class MihomoControllerClient(
     val endpoint: String
         get() = "core-actions"
 
-    fun getProxies(): JSONObject {
-        return invokeAction("getProxies")
+    fun getProxies(timeoutMs: Int = CORE_ACTION_TIMEOUT_MS): JSONObject {
+        return invokeAction("getProxies", timeoutMs = timeoutMs)
             .optJSONObject("data")
             ?: throw IOException("Mihomo core getProxies returned no data")
     }

--- a/app/src/main/java/com/whitedns/vpn/WhiteDnsVpnService.kt
+++ b/app/src/main/java/com/whitedns/vpn/WhiteDnsVpnService.kt
@@ -1952,8 +1952,11 @@ class WhiteDnsVpnService : VpnService() {
             ?: MihomoSelectionPolicy.mainSelectorGroup(snapshot.summary)?.name
             ?: throw IOException("Mihomo traffic selector is unavailable")
         val preferredSelectorRoots = listOf(selectedName)
+        suspend fun getStartupProxies(): JSONObject = withContext(Dispatchers.IO) {
+            controller.getProxies(RUNTIME_HEALTH_TIMEOUT_MS.toInt())
+        }
         var liveProxies = try {
-            withContext(Dispatchers.IO) { controller.getProxies() }
+            getStartupProxies()
         } catch (error: Throwable) {
             if (
                 shouldRetryOriginalAfterAutomaticBridgeFailure(
@@ -1984,7 +1987,7 @@ class WhiteDnsVpnService : VpnService() {
                     "selector=${selection.selectorGroup} selected=${selection.selectedGroup}",
                 )
             }
-            val updated = withContext(Dispatchers.IO) { controller.getProxies() }
+            val updated = getStartupProxies()
             val verified = MihomoControllerProxies.currentSelections(updated, path)
                 .associate { it.selectorGroup to it.selectedGroup }
             if (path.any { verified[it.selectorGroup] != it.selectedGroup }) {
@@ -2013,11 +2016,22 @@ class WhiteDnsVpnService : VpnService() {
             if (!MihomoControllerProxies.isActiveThrough(liveProxies, selectedName, targetName)) {
                 throw IOException("Mihomo traffic selector did not resolve through the requested connection")
             }
-            verifyRuntimeHealth(
-                timeoutMs = RUNTIME_HEALTH_TIMEOUT_MS,
-                event = "mihomo.proxy.health.explicit",
-            )
-            liveProxies = withContext(Dispatchers.IO) { controller.getProxies() }
+            val explicitDelayMs = explicitProfile
+                ?.takeIf { forcedProxyName == null }
+                ?.let { profile ->
+                    realConnectionDelayMs(
+                        controller = controller,
+                        profile = profile,
+                        timeoutMs = FOREGROUND_MIHOMO_DELAY_TIMEOUT_MS,
+                    )
+                }
+            if (explicitDelayMs == null) {
+                verifyRuntimeHealth(
+                    timeoutMs = RUNTIME_HEALTH_TIMEOUT_MS,
+                    event = "mihomo.proxy.health.explicit",
+                )
+            }
+            liveProxies = getStartupProxies()
             if (!MihomoControllerProxies.isActiveThrough(liveProxies, selectedName, targetName)) {
                 throw IOException("Mihomo traffic route changed before startup completed")
             }
@@ -2060,7 +2074,7 @@ class WhiteDnsVpnService : VpnService() {
                             },
                             event = "mihomo.proxy.health.adaptive",
                         )
-                        liveProxies = withContext(Dispatchers.IO) { controller.getProxies() }
+                        liveProxies = getStartupProxies()
                         if (!MihomoControllerProxies.isActiveThrough(liveProxies, selectedName, adaptivePlan.groupName)) {
                             throw IOException("Adaptive traffic route changed before startup completed")
                         }
@@ -2116,7 +2130,7 @@ class WhiteDnsVpnService : VpnService() {
                             "root=$selectedName group=${adaptivePlan.groupName} type=${adaptivePlan.groupType} attempt=$adaptiveAttempt",
                             error,
                         )
-                        liveProxies = withContext(Dispatchers.IO) { controller.getProxies() }
+                        liveProxies = getStartupProxies()
                         if (selectedCountryCode != null) break
                     }
                 }
@@ -2181,7 +2195,7 @@ class WhiteDnsVpnService : VpnService() {
                             timeoutMs = FALLBACK_RUNTIME_HEALTH_TIMEOUT_MS,
                             event = "mihomo.proxy.health.fallback",
                         )
-                        liveProxies = withContext(Dispatchers.IO) { controller.getProxies() }
+                        liveProxies = getStartupProxies()
                         if (!MihomoControllerProxies.isActiveThrough(liveProxies, selectedName, candidate.tag)) {
                             throw IOException("Fallback traffic route changed before startup completed")
                         }
@@ -2202,7 +2216,7 @@ class WhiteDnsVpnService : VpnService() {
                             "attempt=${index + 1}/${orderedCandidates.size}",
                             error,
                         )
-                        liveProxies = withContext(Dispatchers.IO) { controller.getProxies() }
+                        liveProxies = getStartupProxies()
                     }
                 }
                 if (selectedLeaf == null) {


### PR DESCRIPTION
## Summary

- prevent large Mihomo selector graphs from exceeding the startup controller timeout
- apply the longer controller snapshot timeout to explicit, automatic, adaptive, and fallback startup
- reuse the existing real-delay validation for explicitly selected profiles before HTTP health fallback
- bump WhiteVPN to versionName 1.6.5 and versionCode 80

## Root cause

A full getProxies response for a 738-profile subscription could exceed the generic 5-second controller timeout. WhiteVPN then aborted startup even though the requested profile had been selected successfully and its ping/speed test could pass.

## Validation

- ./gradlew :app:generateDebugBuildConfig --rerun-tasks :app:testDebugUnitTest :app:assembleDebug --console=plain
- generated BuildConfig reports VERSION_NAME 1.6.5 and VERSION_CODE 80
- git diff --check
- Android API 37: explicit IT1106 selection applied through both selector levels, runtime health returned HTTP 200, state reached Started, and IT1106 remained active

## Scope

No native or FlClash changes.