### PR TITLE
Release v1.6.6

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,6 +51,7 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         env:
           WHITEDNS_MIHOMO_SUBSCRIPTION_URL: ${{ vars.WHITEDNS_MIHOMO_SUBSCRIPTION_URL }}
+          WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL: ${{ secrets.WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL }}
           WHITEDNS_ENCRYPTED_IP_LIST_URL: ${{ vars.WHITEDNS_ENCRYPTED_IP_LIST_URL }}
         run: ./gradlew testDebugUnitTest assembleDebug
 
@@ -83,6 +84,7 @@ jobs:
           WHITEDNS_MIHOMO_SUBSCRIPTION_KEY: ${{ secrets.WHITEDNS_MIHOMO_SUBSCRIPTION_KEY }}
           WHITEDNS_ENCRYPTED_IP_LIST_KEY: ${{ secrets.WHITEDNS_ENCRYPTED_IP_LIST_KEY }}
           WHITEDNS_MIHOMO_SUBSCRIPTION_URL: ${{ vars.WHITEDNS_MIHOMO_SUBSCRIPTION_URL }}
+          WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL: ${{ secrets.WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL }}
           WHITEDNS_ENCRYPTED_IP_LIST_URL: ${{ vars.WHITEDNS_ENCRYPTED_IP_LIST_URL }}
         run: ./scripts/release.sh
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Subscriptions can be added as an HTTPS URL or pasted directly. WhiteVPN accepts 
 
 ## Built-in subscription
 
-No subscription is required for first use. The default build uses the public [WhiteDNS Mihomo subscription](https://github.com/iampedii/whitedns-sub/blob/main/mihomo.yaml), refreshes it every 30 minutes while connected, and keeps the last valid copy for temporary network failures.
+No subscription is required for first use. Automatic built-in connections try WhiteVPN Private first, then the public [WhiteDNS Mihomo subscription](https://github.com/iampedii/whitedns-sub/blob/main/mihomo.yaml). Each source refreshes every 30 minutes while connected and keeps its own last valid copy for temporary network failures.
 
-Distributors can replace the source at build time with `WHITEDNS_MIHOMO_SUBSCRIPTION_URL`. Custom subscriptions remain separate and can be tested, selected, refreshed, edited or removed in the app.
+Official builds inject the required private source through the `WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL` secret. Local builds can set the same environment variable or `privateMihomoSubscriptionUrl` in `secrets.properties`. Distributors can replace the public source with `WHITEDNS_MIHOMO_SUBSCRIPTION_URL`. Custom subscriptions remain separate and can be tested, selected, refreshed, edited or removed in the app.
 
 ## Community
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,17 @@ val mihomoSubscriptionUrl = httpsBuildUrl(
     "WHITEDNS_MIHOMO_SUBSCRIPTION_URL",
     "https://raw.githubusercontent.com/iampedii/whitedns-sub/refs/heads/main/mihomo.yaml",
 )
+val privateMihomoSubscriptionUrl = (
+    System.getenv("WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL")?.takeIf { it.isNotBlank() }
+        ?: payloadSecrets.getProperty("privateMihomoSubscriptionUrl")?.takeIf { it.isNotBlank() }
+        ?: error(
+            "WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL or privateMihomoSubscriptionUrl is required",
+        )
+    ).also {
+    require(it.startsWith("https://")) {
+        "WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL must use HTTPS"
+    }
+}
 val encryptedIpListUrl = httpsBuildUrl(
     "WHITEDNS_ENCRYPTED_IP_LIST_URL",
     "https://whitedns-encrypted-ip-list.whitedns.workers.dev/v1/results/ips/encrypted",
@@ -79,13 +90,18 @@ android {
         applicationId = "com.whitedns.vpn"
         minSdk = 26
         targetSdk = 35
-        versionCode = 80
-        versionName = "1.6.5"
+        versionCode = 81
+        versionName = "1.6.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         resourceConfigurations += listOf("en", "fa")
 
         buildConfigField("String", "MIHOMO_SUBSCRIPTION_URL", buildConfigStringLiteral(mihomoSubscriptionUrl))
+        buildConfigField(
+            "String",
+            "PRIVATE_MIHOMO_SUBSCRIPTION_URL",
+            buildConfigStringLiteral(privateMihomoSubscriptionUrl),
+        )
         buildConfigField("String", "ENCRYPTED_IP_LIST_URL", buildConfigStringLiteral(encryptedIpListUrl))
         buildConfigField("String", "MIHOMO_SUBSCRIPTION_KEY", buildConfigStringLiteral(mihomoSubscriptionKey))
         buildConfigField("String", "ENCRYPTED_IP_LIST_KEY", buildConfigStringLiteral(encryptedIpListKey))

--- a/app/src/androidTest/java/com/whitedns/vpn/SubscriptionStoreTest.kt
+++ b/app/src/androidTest/java/com/whitedns/vpn/SubscriptionStoreTest.kt
@@ -70,6 +70,25 @@ class SubscriptionStoreTest {
         assertFalse(File(context.filesDir, "profile-delay-cache.json.tmp").exists())
     }
 
+    @Test
+    fun builtInSelectionsAndCatalogsStayIndependent() {
+        val privateCatalog = SubscriptionCatalog(listOf(profile("private", "private-catalog")), 100L)
+        val publicCatalog = SubscriptionCatalog(listOf(profile("public", "public-catalog")), 200L)
+        try {
+            store.saveCatalog(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID, privateCatalog)
+            store.saveCatalog(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID, publicCatalog)
+            store.saveSelectedSubscriptionId(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID)
+
+            assertEquals("private", store.readCatalog(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID)?.profiles?.single()?.tag)
+            assertEquals("public", store.readCatalog(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID)?.profiles?.single()?.tag)
+            assertEquals(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID, store.readSelectedSubscriptionId())
+        } finally {
+            File(context.filesDir, "private-subscription-catalog.json").delete()
+            File(context.filesDir, "subscription-catalog.json").delete()
+            store.saveSelectedSubscriptionId(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID)
+        }
+    }
+
     private fun record(
         profile: ConnectionProfile,
         delayMs: Int?,
@@ -93,5 +112,6 @@ class SubscriptionStoreTest {
         transport = "",
         validationHost = "$tag.example.com",
         fingerprint = fingerprint,
+        outboundJson = "{}",
     )
 }

--- a/app/src/main/java/com/whitedns/vpn/ConnectionSelectionPreferenceStore.kt
+++ b/app/src/main/java/com/whitedns/vpn/ConnectionSelectionPreferenceStore.kt
@@ -23,6 +23,8 @@ class ConnectionSelectionPreferenceStore(context: Context) {
         }.apply()
     }
 
+    fun hasSelectedProfile(subscriptionId: String): Boolean = prefs.contains(key(subscriptionId))
+
     fun readAutomaticTypes(
         subscriptionId: String,
         profiles: List<ConnectionProfile>,
@@ -32,6 +34,9 @@ class ConnectionSelectionPreferenceStore(context: Context) {
             profiles = profiles,
         )
     }
+
+    fun readAutomaticTypes(subscriptionId: String): Set<String> =
+        prefs.getStringSet(typesKey(subscriptionId), emptySet()).orEmpty().toSet()
 
     fun saveAutomaticTypes(
         subscriptionId: String,

--- a/app/src/main/java/com/whitedns/vpn/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/vpn/MainActivity.kt
@@ -158,6 +158,7 @@ class MainActivity : Activity() {
     private lateinit var connectionOrb: ConnectionOrbView
     private lateinit var statusDot: View
     private lateinit var statusText: TextView
+    private lateinit var publicServerNotice: TextView
     private lateinit var connectionDetailsText: TextView
     private lateinit var timerText: TextView
     private lateinit var downloadSpeedText: TextView
@@ -302,6 +303,7 @@ class MainActivity : Activity() {
         setContentView(buildAppShell())
         renderState(VpnState.Stopped)
         refreshLocationOptions()
+        fetchPrivateSubscriptionOnLoad()
         if (savedInstanceState?.getBoolean(STATE_CONNECTION_TESTING_PAGE) == true) {
             val chainSlot = ConnectionChainSlot.fromWireName(
                 savedInstanceState.getString(STATE_CHAIN_PICKER_SLOT),
@@ -633,25 +635,31 @@ class MainActivity : Activity() {
                     selectedName,
                 )
         }
-        val whiteDnsCount = store.readCatalog()?.profiles?.size ?: 0
-        subscriptionsList.addView(
-            subscriptionCard(
-                title = "WhiteVPN",
-                detail = getString(R.string.subscription_builtin_detail, connectionCountLabel(whiteDnsCount)),
-                selected = selectedId == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID,
-                error = "",
-                onTestConnections = {
-                    openSubscriptionConnectionTesting(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID)
-                },
-                actions = listOf(
-                    R.string.subscription_action_select to {
-                        userSubscriptionManager.select(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID)
-                        onSubscriptionSelected()
-                    },
-                    R.string.subscription_action_refresh to { refreshDefaultSubscription() },
+        SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS.forEachIndexed { index, subscriptionId ->
+            val name = builtInSubscriptionName(subscriptionId)
+            val count = store.readCatalog(subscriptionId)?.profiles?.size ?: 0
+            subscriptionsList.addView(
+                subscriptionCard(
+                    title = name,
+                    detail = getString(R.string.subscription_builtin_detail, connectionCountLabel(count)),
+                    selected = selectedId == subscriptionId,
+                    error = "",
+                    onTestConnections = { openSubscriptionConnectionTesting(subscriptionId) },
+                    actions = listOf(
+                        R.string.subscription_action_select to {
+                            userSubscriptionManager.select(subscriptionId)
+                            onSubscriptionSelected()
+                        },
+                        R.string.subscription_action_refresh to {
+                            refreshBuiltInSubscription(subscriptionId, name)
+                        },
+                    ),
                 ),
-            ),
-        )
+                LinearLayout.LayoutParams(-1, -2).apply {
+                    if (index > 0) topMargin = dp(8)
+                },
+            )
+        }
         userSubscriptionManager.list().forEach { item ->
             val updated = item.updatedAt.takeIf { it > 0 }?.let {
                 DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(it)
@@ -861,8 +869,8 @@ class MainActivity : Activity() {
             userSubscriptionManager.select(subscriptionId)
             onSubscriptionSelected()
         }
-        val profiles = if (subscriptionId == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) {
-            store.readCatalog()?.profiles
+        val profiles = if (SubscriptionStore.isBuiltInSubscription(subscriptionId)) {
+            store.readCatalog(subscriptionId)?.profiles
         } else {
             runCatching { userSubscriptionManager.cachedSnapshot(subscriptionId) }
                 .getOrNull()
@@ -1064,12 +1072,12 @@ class MainActivity : Activity() {
         }
     }
 
-    private fun refreshDefaultSubscription() {
+    private fun refreshBuiltInSubscription(subscriptionId: String, name: String) {
         runSubscriptionAction(
-            startMessage = getString(R.string.subscription_refreshing, "WhiteVPN"),
-            refreshProfiles = userSubscriptionManager.selectedId() == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID,
+            startMessage = getString(R.string.subscription_refreshing, name),
+            refreshProfiles = userSubscriptionManager.selectedId() == subscriptionId,
         ) {
-            val refreshed = ConfigRepository(this@MainActivity).refreshDefaultMihomoConfig()
+            val refreshed = ConfigRepository(this@MainActivity).refreshBuiltInMihomoConfig(subscriptionId)
             getString(R.string.subscription_refreshed, connectionCountLabel(refreshed.catalog.profiles.size))
         }
     }
@@ -1130,8 +1138,17 @@ class MainActivity : Activity() {
 
     private fun selectedSubscriptionName(): String {
         val store = SubscriptionStore(this)
-        return store.readUserSubscription(store.readSelectedSubscriptionId())?.name ?: "WhiteVPN"
+        val selectedId = store.readSelectedSubscriptionId()
+        return store.readUserSubscription(selectedId)?.name ?: builtInSubscriptionName(selectedId)
     }
+
+    private fun builtInSubscriptionName(id: String): String = getString(
+        if (id == SubscriptionStore.PUBLIC_SUBSCRIPTION_ID) {
+            R.string.subscription_public_name
+        } else {
+            R.string.subscription_private_name
+        },
+    )
 
     private fun renderConnectionDetails(state: VpnState) {
         if (!::connectionDetailsText.isInitialized) return
@@ -1503,6 +1520,17 @@ class MainActivity : Activity() {
             setTextColor(TEXT_SECONDARY)
             includeFontPadding = false
         }
+        publicServerNotice = TextView(this).apply {
+            setText(R.string.notification_connected_public)
+            gravity = Gravity.CENTER
+            layoutDirection = View.LAYOUT_DIRECTION_LOCALE
+            textDirection = View.TEXT_DIRECTION_FIRST_STRONG
+            textSize = 12f
+            typeface = WhiteDnsBodyBoldTypeface
+            setTextColor(AMBER)
+            includeFontPadding = false
+            visibility = View.GONE
+        }
         timerText = TextView(this).apply {
             gravity = Gravity.CENTER
             layoutDirection = View.LAYOUT_DIRECTION_LTR
@@ -1699,6 +1727,10 @@ class MainActivity : Activity() {
             addView(
                 connectionOrb,
                 LinearLayout.LayoutParams(-2, -2),
+            )
+            addView(
+                publicServerNotice,
+                LinearLayout.LayoutParams(-1, -2).apply { topMargin = dp(8) },
             )
             // Connection status and traffic metrics
             addView(
@@ -3460,7 +3492,11 @@ class MainActivity : Activity() {
         val subscriptions = userSubscriptionManager.list()
         val repository = ConfigRepository(this)
         return buildList {
-            add(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID to getString(R.string.app_name))
+            addAll(
+                SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS.map {
+                    it to builtInSubscriptionName(it)
+                },
+            )
             addAll(subscriptions.map { it.id to it.name })
         }.filter { (subscriptionId, _) -> subscriptionIds == null || subscriptionId in subscriptionIds }
             .mapNotNull { (subscriptionId, subscriptionName) ->
@@ -3873,8 +3909,8 @@ class MainActivity : Activity() {
             val cachedCatalog = withContext(Dispatchers.IO) {
                 val store = SubscriptionStore(this@MainActivity)
                 val selectedId = store.readSelectedSubscriptionId()
-                if (selectedId == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) {
-                    store.readCatalog()
+                if (SubscriptionStore.isBuiltInSubscription(selectedId)) {
+                    store.readCatalog(selectedId)
                 } else {
                     userSubscriptionManager.cachedSnapshot(selectedId)?.catalog
                 }
@@ -3891,6 +3927,25 @@ class MainActivity : Activity() {
 
             if (fetchedCatalog != null) {
                 updateLocationOptions(fetchedCatalog.profiles, resetMissingSelection = true)
+            }
+        }
+    }
+
+    private fun fetchPrivateSubscriptionOnLoad() {
+        if (userSubscriptionManager.selectedId() == SubscriptionStore.PRIVATE_SUBSCRIPTION_ID) return
+        activityScope.launch {
+            runCatching {
+                ConfigRepository(this@MainActivity).fetchOrCachedMihomoConfig(
+                    SubscriptionStore.PRIVATE_SUBSCRIPTION_ID,
+                )
+            }.onSuccess {
+                renderSubscriptions()
+            }.onFailure { error ->
+                DiagnosticLogger.warn(
+                    this@MainActivity,
+                    "activity.privateSubscription.fetch.failed",
+                    error = error,
+                )
             }
         }
     }
@@ -4565,9 +4620,7 @@ class MainActivity : Activity() {
                             null -> R.string.connection_protocol_support_udp_unknown
                         },
                     )
-                    holder.detail.text = if (
-                        selectedSubscriptionId == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID
-                    ) {
+                    holder.detail.text = if (SubscriptionStore.isBuiltInSubscription(selectedSubscriptionId)) {
                         profile.type.uppercase(Locale.US)
                     } else {
                         getString(
@@ -5428,9 +5481,9 @@ class MainActivity : Activity() {
         LocationSelectorOption(countryCode = null, label = getString(R.string.option_automatic))
 
     private fun showSubscriptionSelectorMenu(anchor: View) {
-        val subscriptions = listOf(
-            SubscriptionStore.DEFAULT_SUBSCRIPTION_ID to "WhiteVPN",
-        ) + userSubscriptionManager.list().map { it.id to it.name }
+        val subscriptions = SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS.map {
+            it to builtInSubscriptionName(it)
+        } + userSubscriptionManager.list().map { it.id to it.name }
         val selectedId = userSubscriptionManager.selectedId()
         whiteDnsPopupMenu(anchor).apply {
             subscriptions.forEachIndexed { index, (id, name) ->
@@ -6670,6 +6723,10 @@ class MainActivity : Activity() {
             else -> getString(R.string.route_automatic)
         }
         connectionCountryText.setTextColor(if (state == VpnState.Started) accent else TEXT_SECONDARY)
+        publicServerNotice.visibility = if (
+            state == VpnState.Started &&
+            activeRuntimeSubscriptionId == SubscriptionStore.PUBLIC_SUBSCRIPTION_ID
+        ) View.VISIBLE else View.GONE
         renderConnectionDetails(state)
         refreshActionButton.visibility = if (state == VpnState.Started) View.VISIBLE else View.INVISIBLE
         refreshActionButton.isEnabled = state == VpnState.Started

--- a/app/src/main/java/com/whitedns/vpn/SubConvConverter.kt
+++ b/app/src/main/java/com/whitedns/vpn/SubConvConverter.kt
@@ -39,6 +39,7 @@ internal object SubConvConverter {
                     "vless" -> parseVless(line, names)
                     "vmess" -> parseVmess(line, names)
                     "trojan" -> parseTrojan(line, names)
+                    "anytls" -> parseAnyTls(line, names)
                     "hysteria2", "hy2" -> parseHysteria2(line, names)
                     "socks", "socks5" -> parseSocks(line, names)
                     "ss" -> parseShadowsocks(line, names)
@@ -233,6 +234,26 @@ internal object SubConvConverter {
                 }
                 put("client-fingerprint", query["fp"].orEmpty().ifBlank { "chrome" })
                 query["pcs"]?.takeIf(String::isNotBlank)?.let { put("fingerprint", it) }
+            }
+    }
+
+    private fun parseAnyTls(line: String, names: NameRegistry): JSONObject {
+        val uri = parseUri(line)
+        val endpoint = endpoint(uri)
+        if (endpoint.userInfo.isBlank()) throw ParseError()
+        val query = parseQuery(uri.rawQuery)
+        val sni = query["sni"].orEmpty().ifBlank { query["peer"].orEmpty() }
+        return JSONObject()
+            .put("name", names.register(name(uri)))
+            .put("type", "anytls")
+            .put("server", endpoint.host)
+            .put("port", endpoint.port)
+            .put("password", endpoint.userInfo)
+            .put("udp", true)
+            .put("skip-cert-verify", false)
+            .apply {
+                sni.takeIf(String::isNotBlank)?.let { put("sni", it) }
+                query["hpkp"]?.takeIf(String::isNotBlank)?.let { put("fingerprint", it) }
             }
     }
 

--- a/app/src/main/java/com/whitedns/vpn/SubscriptionSnapshot.kt
+++ b/app/src/main/java/com/whitedns/vpn/SubscriptionSnapshot.kt
@@ -151,12 +151,12 @@ internal class AndroidSubscriptionSnapshotAdapter(
     private val store: SubscriptionStore,
 ) : SubscriptionSnapshotPersistence {
     override fun read(id: String): SubscriptionSnapshotEntry? {
-        if (id == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) {
-            val file = defaultSnapshotFile()
+        if (SubscriptionStore.isBuiltInSubscription(id)) {
+            val file = builtInSnapshotFile(id)
             return SubscriptionSnapshotEntry(
-                source = managedSource(),
+                source = managedSource(id),
                 cachedYaml = file.takeIf { it.isFile && it.length() > 0L }?.readText(),
-                fetchedAt = store.readCatalog()?.fetchedAt
+                fetchedAt = store.readCatalog(id)?.fetchedAt
                     ?: file.lastModified().takeIf { it > 0L }
                     ?: 0L,
             )
@@ -183,10 +183,10 @@ internal class AndroidSubscriptionSnapshotAdapter(
     }
 
     override fun save(id: String, subscription: CompiledSubscription) {
-        if (id == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) {
-            val file = defaultSnapshotFile()
+        if (SubscriptionStore.isBuiltInSubscription(id)) {
+            val file = builtInSnapshotFile(id)
             replaceSubscriptionSnapshot(file, subscription.snapshot.rawConfig) {
-                store.saveCatalog(subscription.snapshot.catalog)
+                store.saveCatalog(id, subscription.snapshot.catalog)
             }
             return
         }
@@ -207,10 +207,11 @@ internal class AndroidSubscriptionSnapshotAdapter(
     }
 
     override fun recordFailure(id: String, error: Throwable) {
-        if (id == SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) {
+        if (SubscriptionStore.isBuiltInSubscription(id)) {
             DiagnosticLogger.warn(
                 context,
-                "subscription.default.refresh.failed",
+                "subscription.builtin.refresh.failed",
+                "subscription=$id",
                 error = error,
             )
             return
@@ -226,8 +227,12 @@ internal class AndroidSubscriptionSnapshotAdapter(
         }
     }
 
-    private fun managedSource(): SubscriptionSource.ManagedHttps {
-        val url = WhiteDnsConfig.MIHOMO_SUBSCRIPTION_URL
+    private fun managedSource(id: String): SubscriptionSource.ManagedHttps {
+        val url = if (id == SubscriptionStore.PRIVATE_SUBSCRIPTION_ID) {
+            WhiteDnsConfig.PRIVATE_MIHOMO_SUBSCRIPTION_URL
+        } else {
+            WhiteDnsConfig.MIHOMO_SUBSCRIPTION_URL
+        }
         val encrypted = runCatching {
             URI(url).path.orEmpty().contains("encrypted", ignoreCase = true)
         }
@@ -239,8 +244,14 @@ internal class AndroidSubscriptionSnapshotAdapter(
         )
     }
 
-    private fun defaultSnapshotFile(): File =
-        File(context.filesDir, "mihomo/encrypted_mihomo_subscription.yaml")
+    private fun builtInSnapshotFile(id: String): File = File(
+        context.filesDir,
+        if (id == SubscriptionStore.PUBLIC_SUBSCRIPTION_ID) {
+            "mihomo/encrypted_mihomo_subscription.yaml"
+        } else {
+            "mihomo/private_mihomo_subscription.yaml"
+        },
+    )
 }
 
 internal data class SubscriptionSnapshotEntry(

--- a/app/src/main/java/com/whitedns/vpn/SubscriptionStore.kt
+++ b/app/src/main/java/com/whitedns/vpn/SubscriptionStore.kt
@@ -110,7 +110,7 @@ class SubscriptionStore(private val context: Context) {
         .ifBlank { DEFAULT_SUBSCRIPTION_ID }
 
     fun saveSelectedSubscriptionId(id: String) {
-        val validId = if (id == DEFAULT_SUBSCRIPTION_ID || readUserSubscription(id) != null) {
+        val validId = if (isBuiltInSubscription(id) || readUserSubscription(id) != null) {
             id
         } else {
             DEFAULT_SUBSCRIPTION_ID
@@ -121,8 +121,8 @@ class SubscriptionStore(private val context: Context) {
             .apply()
     }
 
-    fun readCatalog(): SubscriptionCatalog? {
-        val file = catalogFile()
+    fun readCatalog(subscriptionId: String = DEFAULT_SUBSCRIPTION_ID): SubscriptionCatalog? {
+        val file = catalogFile(subscriptionId)
         if (!file.exists() || file.length() == 0L) return null
         return runCatching {
             val root = JSONObject(file.readText())
@@ -152,7 +152,7 @@ class SubscriptionStore(private val context: Context) {
         }.getOrNull()
     }
 
-    fun saveCatalog(catalog: SubscriptionCatalog) {
+    fun saveCatalog(subscriptionId: String, catalog: SubscriptionCatalog) {
         val profiles = JSONArray()
         catalog.profiles.forEach { profile ->
             profiles.put(
@@ -168,7 +168,7 @@ class SubscriptionStore(private val context: Context) {
             )
         }
         writeFile(
-            catalogFile(),
+            catalogFile(subscriptionId),
             JSONObject()
                 .put("fetchedAt", catalog.fetchedAt)
                 .put("profiles", profiles)
@@ -344,7 +344,10 @@ class SubscriptionStore(private val context: Context) {
         writeTextAtomically(delaysFile(), items.toString())
     }
 
-    private fun catalogFile(): File = File(context.filesDir, CATALOG_FILE)
+    private fun catalogFile(subscriptionId: String): File = File(
+        context.filesDir,
+        if (subscriptionId == PUBLIC_SUBSCRIPTION_ID) PUBLIC_CATALOG_FILE else PRIVATE_CATALOG_FILE,
+    )
 
     private fun delaysFile(): File = File(context.filesDir, DELAYS_FILE)
 
@@ -384,8 +387,14 @@ class SubscriptionStore(private val context: Context) {
     }
 
     companion object {
-        const val DEFAULT_SUBSCRIPTION_ID = "whitedns"
-        private const val CATALOG_FILE = "subscription-catalog.json"
+        const val PRIVATE_SUBSCRIPTION_ID = "whitevpn-private"
+        const val PUBLIC_SUBSCRIPTION_ID = "whitedns"
+        const val DEFAULT_SUBSCRIPTION_ID = PRIVATE_SUBSCRIPTION_ID
+        val BUILT_IN_SUBSCRIPTION_IDS = listOf(PRIVATE_SUBSCRIPTION_ID, PUBLIC_SUBSCRIPTION_ID)
+        fun isBuiltInSubscription(id: String): Boolean = id in BUILT_IN_SUBSCRIPTION_IDS
+
+        private const val PRIVATE_CATALOG_FILE = "private-subscription-catalog.json"
+        private const val PUBLIC_CATALOG_FILE = "subscription-catalog.json"
         private const val DELAYS_FILE = "profile-delay-cache.json"
         private const val USER_SUBSCRIPTIONS_FILE = "user-subscriptions.json"
         private const val USER_SUBSCRIPTION_PREFS = "white_dns_user_subscriptions"

--- a/app/src/main/java/com/whitedns/vpn/WhiteDnsConfig.kt
+++ b/app/src/main/java/com/whitedns/vpn/WhiteDnsConfig.kt
@@ -24,6 +24,7 @@ object WhiteDnsConfig {
 
     // Injected at build time from the environment with production defaults; see app/build.gradle.kts.
     val MIHOMO_SUBSCRIPTION_URL: String get() = BuildConfig.MIHOMO_SUBSCRIPTION_URL
+    val PRIVATE_MIHOMO_SUBSCRIPTION_URL: String get() = BuildConfig.PRIVATE_MIHOMO_SUBSCRIPTION_URL
     val ENCRYPTED_IP_LIST_URL: String get() = BuildConfig.ENCRYPTED_IP_LIST_URL
 
     // Release builds fail when these are unset; debug builds get an empty string.
@@ -107,16 +108,18 @@ class ConfigRepository(private val context: Context) {
 
     suspend fun fetchOrCachedCatalog(): SubscriptionCatalog = fetchOrCachedMihomoConfig().catalog
 
-    suspend fun refreshDefaultMihomoConfig(): MihomoSubscriptionSnapshot = withContext(Dispatchers.IO) {
+    suspend fun refreshBuiltInMihomoConfig(
+        subscriptionId: String,
+    ): MihomoSubscriptionSnapshot = withContext(Dispatchers.IO) {
         subscriptionSnapshots.resolve(
-            SubscriptionStore.DEFAULT_SUBSCRIPTION_ID,
+            subscriptionId,
             SubscriptionRefreshPolicy.Force,
         ).snapshot.also { snapshot ->
-            pruneProfileCaches(snapshot.catalog)
+            pruneProfileCaches(subscriptionId, snapshot.catalog)
             DiagnosticLogger.info(
                 context,
                 "subscription.fetch.manual.success",
-                "profiles=${snapshot.catalog.profiles.size} groups=${snapshot.summary.groups.size}",
+                "subscription=$subscriptionId profiles=${snapshot.catalog.profiles.size} groups=${snapshot.summary.groups.size}",
             )
         }
     }
@@ -125,7 +128,7 @@ class ConfigRepository(private val context: Context) {
         var successful = 0
         var failed = 0
         var fresh = 0
-        val ids = listOf(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID) +
+        val ids = SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS +
             userSubscriptionManager.list().map(UserSubscription::id)
         ids.forEach { id ->
             try {
@@ -161,7 +164,7 @@ class ConfigRepository(private val context: Context) {
             }
             .getOrNull()
             ?.also { snapshot ->
-                pruneProfileCaches(snapshot.catalog)
+                pruneProfileCaches(selectedId, snapshot.catalog)
                 DiagnosticLogger.info(
                     context,
                     "subscription.cache.local",
@@ -181,24 +184,29 @@ class ConfigRepository(private val context: Context) {
         return runCatching { subscriptionSnapshots.cached(subscriptionId) }.getOrNull()
     }
 
-    suspend fun fetchOrCachedMihomoConfig(): MihomoSubscriptionSnapshot = withContext(Dispatchers.IO) {
-        val selectedId = subscriptionStore.readSelectedSubscriptionId()
-        val resolution = subscriptionSnapshots.resolve(selectedId)
-        pruneProfileCaches(resolution.snapshot.catalog)
+    suspend fun fetchOrCachedMihomoConfig(
+        subscriptionId: String = subscriptionStore.readSelectedSubscriptionId(),
+    ): MihomoSubscriptionSnapshot = withContext(Dispatchers.IO) {
+        val resolution = subscriptionSnapshots.resolve(subscriptionId)
+        pruneProfileCaches(subscriptionId, resolution.snapshot.catalog)
         DiagnosticLogger.info(
             context,
             "subscription.snapshot.resolved",
-            "subscription=$selectedId origin=${resolution.origin} profiles=${resolution.snapshot.catalog.profiles.size} groups=${resolution.snapshot.summary.groups.size} fetchedAt=${resolution.snapshot.catalog.fetchedAt}",
+            "subscription=$subscriptionId origin=${resolution.origin} profiles=${resolution.snapshot.catalog.profiles.size} groups=${resolution.snapshot.summary.groups.size} fetchedAt=${resolution.snapshot.catalog.fetchedAt}",
         )
         resolution.snapshot
     }
 
-    private fun pruneProfileCaches(catalog: SubscriptionCatalog) {
+    private fun pruneProfileCaches(subscriptionId: String, catalog: SubscriptionCatalog) {
         val delayRemoved = subscriptionStore.pruneConnectionDelayRecords(
-            subscriptionId = subscriptionStore.readSelectedSubscriptionId(),
+            subscriptionId = subscriptionId,
             profiles = catalog.profiles,
         )
-        val lastSelectedRemoved = scanStateStore.pruneLastSelectedProfile(catalog.profiles)
+        val lastSelectedRemoved = if (subscriptionId == subscriptionStore.readSelectedSubscriptionId()) {
+            scanStateStore.pruneLastSelectedProfile(catalog.profiles)
+        } else {
+            false
+        }
         if (delayRemoved > 0 || lastSelectedRemoved) {
             DiagnosticLogger.info(
                 context,

--- a/app/src/main/java/com/whitedns/vpn/WhiteDnsVpnService.kt
+++ b/app/src/main/java/com/whitedns/vpn/WhiteDnsVpnService.kt
@@ -45,9 +45,13 @@ internal class MihomoCoreSetupTimeoutException :
     IOException("Mihomo core setup did not finish within 60 seconds")
 
 internal data class ConnectionStartupExclusion(
+    val subscriptionId: String = "",
     val endpoint: CleanIpResult? = null,
     val profileFingerprint: String = "",
-)
+) {
+    fun forSubscription(id: String): ConnectionStartupExclusion =
+        takeIf { subscriptionId == id } ?: ConnectionStartupExclusion()
+}
 
 internal enum class AutomaticBridgeFailurePhase {
     ConfigCoreOrController,
@@ -146,6 +150,47 @@ internal object PostConnectHealthPolicy {
 internal object DefaultNetworkDnsReplayPolicy {
     const val MAX_RETRY_ATTEMPTS = 1
 }
+
+internal object BuiltInSubscriptionStartupPolicy {
+    fun sourceIds(selectedSubscriptionId: String, explicitProfile: ConnectionProfile?): List<String> =
+        if (
+            SubscriptionStore.isBuiltInSubscription(selectedSubscriptionId) &&
+            explicitProfile == null
+        ) {
+            SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS
+        } else {
+            listOf(selectedSubscriptionId)
+        }
+
+    fun canFallback(error: Throwable): Boolean =
+        error is IOException &&
+            error !is MihomoCoreBusyException &&
+            error !is MihomoCoreSetupTimeoutException
+
+    suspend fun <T> firstSuccessful(
+        sourceIds: List<String>,
+        onFallback: (from: String, to: String, error: Throwable) -> Unit = { _, _, _ -> },
+        attempt: suspend (String) -> T,
+    ): T {
+        require(sourceIds.isNotEmpty())
+        sourceIds.forEachIndexed { index, sourceId ->
+            try {
+                return attempt(sourceId)
+            } catch (error: Throwable) {
+                if (index == sourceIds.lastIndex || !canFallback(error)) throw error
+                onFallback(sourceId, sourceIds[index + 1], error)
+            }
+        }
+        error("No subscription source was attempted")
+    }
+}
+
+internal fun connectedNotificationTextRes(subscriptionId: String): Int =
+    if (subscriptionId == SubscriptionStore.PUBLIC_SUBSCRIPTION_ID) {
+        R.string.notification_connected_public
+    } else {
+        R.string.notification_connected
+    }
 
 internal object VpnTunnelNetwork {
     const val IPV4_ADDRESS = "172.19.0.1"
@@ -611,13 +656,15 @@ class WhiteDnsVpnService : VpnService() {
         }
         DiagnosticLogger.info(this, "$eventPrefix.start")
         val exclusion = ConnectionStartupExclusion(
+            subscriptionId = activeSubscriptionId,
             endpoint = activeEndpoint,
             profileFingerprint = activeConnectionFingerprint,
         )
         DiagnosticLogger.info(
             this,
             "$eventPrefix.connection.excluded",
-            "endpoint=${exclusion.endpoint != null} profile=${exclusion.profileFingerprint.isNotBlank()}",
+            "subscription=${exclusion.subscriptionId} endpoint=${exclusion.endpoint != null} " +
+                "profile=${exclusion.profileFingerprint.isNotBlank()}",
         )
         publishState(VpnState.Starting)
         startForeground(NOTIFICATION_ID, serviceNotification(getString(R.string.notification_starting)))
@@ -1260,7 +1307,6 @@ class WhiteDnsVpnService : VpnService() {
         networkMonitor.start()
 
         val selectedSubscriptionId = subscriptionStore.readSelectedSubscriptionId()
-        val showServer = selectedSubscriptionId != SubscriptionStore.DEFAULT_SUBSCRIPTION_ID
         val chainSettings = connectionChainPreferenceStore.read()
         if (chainSettings.isActive) {
             if (quickSpeedRequested) {
@@ -1286,83 +1332,119 @@ class WhiteDnsVpnService : VpnService() {
             )
             return
         }
-        val snapshot = configRepository.fetchOrCachedMihomoConfig()
-        ensureStartupActive(eventPrefix)
-        val eligibleProfiles = eligibleProfilesForRuntime(snapshot.catalog)
-        val requestedExplicitProfile = connectionSelectionPreferenceStore.readSelectedProfile(
-            selectedSubscriptionId,
-            snapshot.catalog.profiles,
-        )
-        val selectedAutomaticTypes = connectionSelectionPreferenceStore.readAutomaticTypes(
-            selectedSubscriptionId,
-            snapshot.catalog.profiles,
-        )
-        val explicitProfile = requestedExplicitProfile?.let { requested ->
-            eligibleProfiles.firstOrNull { it.fingerprint == requested.fingerprint }
-        }
-        if (requestedExplicitProfile != null && explicitProfile == null) {
-            connectionSelectionPreferenceStore.saveSelectedProfile(selectedSubscriptionId, null)
-            DiagnosticLogger.warn(
-                this,
-                "connection.selection.ineligible",
-                "profile=${requestedExplicitProfile.tag} fallback=automatic",
+
+        val snapshots = mutableMapOf<String, MihomoSubscriptionSnapshot>()
+        var explicitProfile: ConnectionProfile? = null
+        if (connectionSelectionPreferenceStore.hasSelectedProfile(selectedSubscriptionId)) {
+            val selectedSnapshot = configRepository.fetchOrCachedMihomoConfig(selectedSubscriptionId)
+            snapshots[selectedSubscriptionId] = selectedSnapshot
+            val requested = connectionSelectionPreferenceStore.readSelectedProfile(
+                selectedSubscriptionId,
+                selectedSnapshot.catalog.profiles,
             )
+            explicitProfile = requested?.let { profile ->
+                eligibleProfilesForRuntime(selectedSnapshot.catalog)
+                    .firstOrNull { it.fingerprint == profile.fingerprint }
+            }
+            if (requested == null || explicitProfile == null) {
+                connectionSelectionPreferenceStore.saveSelectedProfile(selectedSubscriptionId, null)
+                DiagnosticLogger.warn(
+                    this,
+                    "connection.selection.ineligible",
+                    "profile=${requested?.tag.orEmpty()} fallback=automatic",
+                )
+            }
         }
+
+        val selectedAutomaticTypes = connectionSelectionPreferenceStore
+            .readAutomaticTypes(selectedSubscriptionId)
         val selectedCountryCode = locationPreferenceStore.readSelectedCountryCode()
             .takeIf { explicitProfile == null }
-        val automaticProfiles = ConnectionTypeSelectionPolicy.filterProfiles(
-            eligibleProfiles,
-            selectedAutomaticTypes,
-        )
-        if (explicitProfile == null && automaticProfiles.isEmpty()) {
-            throw IOException("No eligible connections match the selected types")
-        }
-        val profiles = explicitProfile?.let(::listOf) ?: profilesForSelectedLocation(
-            profiles = automaticProfiles,
-            selectedCountryCode = selectedCountryCode,
-        )
-        DiagnosticLogger.info(
-            this,
-            "connection.selection",
-            "mode=${if (explicitProfile == null) "automatic" else "explicit"} " +
-                "profile=${explicitProfile?.tag.orEmpty()} types=${selectedAutomaticTypes.sorted().joinToString(",")}",
-        )
         val splitTunnelPlan = resolveSplitTunnelRuntimePlan()
         val frontingIps = frontingIpPreferenceStore.readFrontingIps()
-        val preferences = captureSessionPlanPreferences(
-            selectedSubscriptionId = selectedSubscriptionId,
-            explicitProfile = explicitProfile,
-            selectedAutomaticTypes = selectedAutomaticTypes,
-            frontingIps = frontingIps,
-        )
         if (quickSpeedRequested && frontingIps.isNotEmpty()) {
             DiagnosticLogger.info(this, "mihomo.quickSpeed.skipped", "reason=fronting")
         }
-        val (startedRuntime, startupNotice) = withContext(Dispatchers.IO) {
-            if (frontingIps.isNotEmpty()) {
-                connectWithFrontingIpsOrOriginal(
-                    eventPrefix = eventPrefix,
-                    snapshot = snapshot,
-                    profiles = profiles,
-                    splitTunnelPlan = splitTunnelPlan,
-                    selectedCountryCode = selectedCountryCode,
-                    exclusion = exclusion,
-                    frontingIps = frontingIps,
-                    preferences = preferences,
-                    availableProfiles = eligibleProfiles,
+
+        val sourceIds = BuiltInSubscriptionStartupPolicy.sourceIds(
+            selectedSubscriptionId,
+            explicitProfile,
+        )
+        val (startedRuntime, startupNotice, showServer) =
+            BuiltInSubscriptionStartupPolicy.firstSuccessful(
+                sourceIds = sourceIds,
+                onFallback = { from, to, error ->
+                    DiagnosticLogger.warn(
+                        this,
+                        "connection.subscription.fallback",
+                        "from=$from to=$to",
+                        error,
+                    )
+                },
+            ) { sourceId ->
+                val snapshot = snapshots[sourceId]
+                    ?: configRepository.fetchOrCachedMihomoConfig(sourceId)
+                ensureStartupActive(eventPrefix)
+                val eligibleProfiles = eligibleProfilesForRuntime(snapshot.catalog)
+                val sourceExplicitProfile = explicitProfile.takeIf { sourceId == selectedSubscriptionId }
+                val automaticProfiles = ConnectionTypeSelectionPolicy.filterProfiles(
+                    eligibleProfiles,
+                    selectedAutomaticTypes,
                 )
-            } else {
-                connectWithOriginal(
-                    snapshot = snapshot,
-                    splitTunnelPlan = splitTunnelPlan,
+                if (sourceExplicitProfile == null && automaticProfiles.isEmpty()) {
+                    throw IOException("No eligible connections match the selected types")
+                }
+                val profiles = sourceExplicitProfile?.let(::listOf) ?: profilesForSelectedLocation(
+                    profiles = automaticProfiles,
                     selectedCountryCode = selectedCountryCode,
-                    preferences = preferences,
-                    availableProfiles = eligibleProfiles,
-                    excludedProfileFingerprint = exclusion.profileFingerprint,
-                    quickSpeedRequested = quickSpeedRequested,
-                ) to null
+                )
+                if (profiles.isEmpty()) {
+                    throw IOException("No eligible connections match the selected location")
+                }
+                DiagnosticLogger.info(
+                    this,
+                    "connection.selection",
+                    "subscription=$sourceId mode=${if (sourceExplicitProfile == null) "automatic" else "explicit"} " +
+                        "profile=${sourceExplicitProfile?.tag.orEmpty()} types=${selectedAutomaticTypes.sorted().joinToString(",")}",
+                )
+                val preferences = captureSessionPlanPreferences(
+                    selectedSubscriptionId = sourceId,
+                    explicitProfile = sourceExplicitProfile,
+                    selectedAutomaticTypes = selectedAutomaticTypes,
+                    frontingIps = frontingIps,
+                )
+                val sourceExclusion = exclusion.forSubscription(sourceId)
+                val (startedRuntime, startupNotice) = withContext(Dispatchers.IO) {
+                    if (frontingIps.isNotEmpty()) {
+                        connectWithFrontingIpsOrOriginal(
+                            eventPrefix = eventPrefix,
+                            snapshot = snapshot,
+                            profiles = profiles,
+                            splitTunnelPlan = splitTunnelPlan,
+                            selectedCountryCode = selectedCountryCode,
+                            exclusion = sourceExclusion,
+                            frontingIps = frontingIps,
+                            preferences = preferences,
+                            availableProfiles = eligibleProfiles,
+                        )
+                    } else {
+                        connectWithOriginal(
+                            snapshot = snapshot,
+                            splitTunnelPlan = splitTunnelPlan,
+                            selectedCountryCode = selectedCountryCode,
+                            preferences = preferences,
+                            availableProfiles = eligibleProfiles,
+                            excludedProfileFingerprint = sourceExclusion.profileFingerprint,
+                            quickSpeedRequested = quickSpeedRequested,
+                        ) to null
+                    }
+                }
+                Triple(
+                    startedRuntime,
+                    startupNotice,
+                    !SubscriptionStore.isBuiltInSubscription(sourceId),
+                )
             }
-        }
         applyStartedRuntime(
             startedRuntimeCandidate = startedRuntime,
             eventPrefix = eventPrefix,
@@ -1473,7 +1555,7 @@ class WhiteDnsVpnService : VpnService() {
     ): StartedMihomoRuntime {
         val subscriptions = subscriptionStore.readUserSubscriptions()
         val sourceIds = buildList {
-            add(SubscriptionStore.DEFAULT_SUBSCRIPTION_ID)
+            addAll(SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS)
             addAll(subscriptions.map(UserSubscription::id))
         }.distinct()
         val cachedSources = sourceIds.mapNotNull { subscriptionId ->
@@ -1482,7 +1564,13 @@ class WhiteDnsVpnService : VpnService() {
             ConnectionChainSource(
                 subscriptionId = subscriptionId,
                 subscriptionName = subscriptions.firstOrNull { it.id == subscriptionId }?.name
-                    ?: getString(R.string.app_name),
+                    ?: getString(
+                        if (subscriptionId == SubscriptionStore.PUBLIC_SUBSCRIPTION_ID) {
+                            R.string.subscription_public_name
+                        } else {
+                            R.string.subscription_private_name
+                        },
+                    ),
                 snapshot = snapshot,
             )
         }
@@ -2828,7 +2916,7 @@ class WhiteDnsVpnService : VpnService() {
         sessionStartedAtElapsedMs = SystemClock.elapsedRealtime()
         publishState(VpnState.Started, notice)
         getSystemService(NotificationManager::class.java)
-            .notify(NOTIFICATION_ID, serviceNotification(getString(R.string.notification_connected)))
+            .notify(NOTIFICATION_ID, serviceNotification(connectedNotificationText()))
         DiagnosticLogger.info(
             this,
             "$eventPrefix.started",
@@ -4027,7 +4115,7 @@ class WhiteDnsVpnService : VpnService() {
                 serviceNotification(
                     getString(
                         if (preservedState == VpnState.Started) {
-                            R.string.notification_connected
+                            connectedNotificationTextRes(activeSubscriptionId)
                         } else {
                             R.string.notification_starting
                         },
@@ -4436,7 +4524,7 @@ class WhiteDnsVpnService : VpnService() {
                         publishState(VpnState.Started)
                         getSystemService(NotificationManager::class.java).notify(
                             NOTIFICATION_ID,
-                            serviceNotification(getString(R.string.notification_connected)),
+                            serviceNotification(connectedNotificationText()),
                         )
                         startBackgroundSubscriptionRefresh()
                     }
@@ -4672,6 +4760,9 @@ class WhiteDnsVpnService : VpnService() {
 
         return builder.build()
     }
+
+    private fun connectedNotificationText(): String =
+        getString(connectedNotificationTextRes(activeSubscriptionId))
 
     private fun serviceActionPendingIntent(action: String): PendingIntent {
         val requestCode = when (action) {

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -5,6 +5,7 @@
     <string name="notification_title">WhiteVPN</string>
     <string name="notification_starting">در حال اتصال</string>
     <string name="notification_connected">متصل</string>
+    <string name="notification_connected_public">متصل با سرورهای عمومی</string>
     <string name="notification_action_disconnect">قطع اتصال</string>
     <string name="notification_action_reconnect">اتصال دوباره</string>
     <string name="footer_copyright">کپی‌رایت WhiteVPN</string>
@@ -54,6 +55,8 @@
     <string name="subscription_from_clipboard">از کلیپ‌بورد</string>
     <string name="subscription_clipboard_empty">کلیپ‌بورد حاوی سابسکریپشن یا کانفیگ نیست.</string>
     <string name="subscription_builtin_detail">داخلی · %1$s</string>
+    <string name="subscription_private_name">WhiteVPN اختصاصی</string>
+    <string name="subscription_public_name">WhiteVPN عمومی</string>
     <string name="subscription_detail">%1$s · %2$s · %3$s</string>
     <string name="subscription_never_updated">هرگز</string>
     <string name="subscription_selected_badge">انتخاب‌شده</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="notification_title">WhiteVPN</string>
     <string name="notification_starting">Connecting</string>
     <string name="notification_connected">Connected</string>
+    <string name="notification_connected_public">Connected using public servers</string>
     <string name="notification_action_disconnect">Disconnect</string>
     <string name="notification_action_reconnect">Reconnect</string>
     <string name="footer_copyright">Copyright WhiteVPN</string>
@@ -53,6 +54,8 @@
     <string name="subscription_from_clipboard">From Clipboard</string>
     <string name="subscription_clipboard_empty">The clipboard does not contain a subscription or configuration.</string>
     <string name="subscription_builtin_detail">Built-in · %1$s</string>
+    <string name="subscription_private_name">WhiteVPN Private</string>
+    <string name="subscription_public_name">WhiteVPN Public fallback</string>
     <string name="subscription_detail">%1$s · %2$s · %3$s</string>
     <string name="subscription_never_updated">Never</string>
     <string name="subscription_selected_badge">Selected</string>

--- a/app/src/test/java/com/whitedns/vpn/MihomoRuntimeConfigBuilderTest.kt
+++ b/app/src/test/java/com/whitedns/vpn/MihomoRuntimeConfigBuilderTest.kt
@@ -1129,6 +1129,73 @@ class MihomoRuntimeConfigBuilderTest {
     }
 
     @Test
+    fun connectionOptionsHonorAmneziaV3SubscriptionUnlessOverrideEnabled() {
+        val yaml = """
+            proxies:
+              - name: AWG3
+                type: wireguard
+                server: 192.0.2.10
+                port: 443
+                amnezia-wg-option:
+                  version: 3
+                  jc: 2
+                  jmin: 32
+                  jmax: 64
+                  s1: 16
+                  h1: 101
+                  i1: '<b 0x01020304>'
+                  header-protection-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+                  content-padding-addition: '8-24'
+                  rekey-after-time: '90s'
+                  rekey-timeout: '4s'
+                  reject-after-time: '150s'
+                  keepalive-timeout: '25s'
+                  max-handshake-attempts: '8'
+                  random-trailers: false
+                  disable-cookies: true
+        """.trimIndent()
+        val appOverride = MihomoConnectionOptions(
+            amneziaNoiseEnabled = true,
+            amneziaNoise = AmneziaNoiseSettings(
+                count = 5,
+                minSize = 50,
+                maxSize = 100,
+                version = 3,
+                headerProtectionKey = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+                contentPaddingAddition = "16-32",
+                rekeyAfterTime = "120s",
+                rekeyTimeout = "5s",
+                rejectAfterTime = "180s",
+                keepaliveTimeout = "30s",
+                maxHandshakeAttempts = "10",
+                randomTrailers = true,
+                disableCookies = false,
+            ),
+        )
+
+        assertEquals(
+            yaml,
+            MihomoConnectionOptionsPatcher.patch(
+                yaml,
+                appOverride.copy(amneziaNoiseEnabled = false),
+            ),
+        )
+
+        val patched = MihomoConnectionOptionsPatcher.patch(yaml, appOverride)
+        assertTrue(patched.contains("jc: 5"))
+        assertTrue(patched.contains("jmin: 50"))
+        assertTrue(patched.contains("jmax: 100"))
+        assertTrue(patched.contains("s1: 16"))
+        assertTrue(patched.contains("h1: 101"))
+        assertTrue(patched.contains("i1: '<b 0x01020304>'"))
+        assertTrue(patched.contains("header-protection-key: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB='"))
+        assertTrue(patched.contains("content-padding-addition: '16-32'"))
+        assertTrue(patched.contains("random-trailers: true"))
+        assertTrue(patched.contains("disable-cookies: false"))
+        assertFalse(patched.contains("header-protection-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+    }
+
+    @Test
     fun dpiBypassPatcherAddsLocalProxyAndDialerProxyOnlyWhenEnabled() {
         val yaml = """
             proxies:

--- a/app/src/test/java/com/whitedns/vpn/UserSubscriptionImporterTest.kt
+++ b/app/src/test/java/com/whitedns/vpn/UserSubscriptionImporterTest.kt
@@ -278,6 +278,22 @@ class UserSubscriptionImporterTest {
     }
 
     @Test
+    fun importerConvertsAnyTlsShareLinks() {
+        val imported = UserSubscriptionImporter.import(
+            "anytls://password%21@anytls.example.com:443?peer=cn.bing.com&insecure=1&udp=1#AnyTLS",
+            nowMs = 123L,
+        )
+        val snapshot = MihomoConfigParser.parse(imported.yaml, 123L)
+
+        assertEquals(UserSubscriptionFormat.Links, imported.format)
+        assertEquals("anytls", snapshot.catalog.profiles.single().type)
+        assertTrue(imported.yaml.contains("password: 'password!'"))
+        assertTrue(imported.yaml.contains("sni: 'cn.bing.com'"))
+        assertTrue(imported.yaml.contains("udp: true"))
+        assertTrue(imported.yaml.contains("skip-cert-verify: false"))
+    }
+
+    @Test
     fun importerConvertsBase64WireGuardLinksAndTheirMihomoOptions() {
         val link = "wireguard://private%2Bkey%3D@engage.example.com:2408" +
             "?address=172.16.0.2%2F32%2C2606%3A4700%3A110%3A8765%3A%3A2%2F128" +
@@ -331,6 +347,53 @@ class UserSubscriptionImporterTest {
         assertEquals(UserSubscriptionFormat.Mihomo, imported.format)
         assertEquals(1, imported.connectionCount)
         assertEquals(2, MihomoConfigParser.parse(imported.yaml).summary.groups.size)
+    }
+
+    @Test
+    fun importerPreservesCompleteNativeMihomoAmneziaV3Config() {
+        val source = """
+            proxies:
+              - name: AWG3
+                type: wireguard
+                server: 192.0.2.10
+                port: 443
+                amnezia-wg-option:
+                  version: 3
+                  jc: 4
+                  jmin: 40
+                  jmax: 70
+                  s1: 16
+                  s2: 17
+                  s3: 18
+                  s4: 19
+                  h1: 101
+                  h2: 102
+                  h3: 103
+                  h4: 104
+                  i1: '<b 0x01020304>'
+                  i2: '<b 0x05060708>'
+                  header-protection-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+                  content-padding-addition: '8-24'
+                  rekey-after-time: '90s'
+                  rekey-timeout: '4s'
+                  reject-after-time: '150s'
+                  keepalive-timeout: '25s'
+                  max-handshake-attempts: '8'
+                  random-trailers: true
+                  disable-cookies: true
+            proxy-groups:
+              - name: Proxy
+                type: select
+                proxies: [AWG3]
+            rules:
+              - MATCH,Proxy
+        """.trimIndent()
+
+        val imported = UserSubscriptionImporter.import(source)
+
+        assertEquals(UserSubscriptionFormat.Mihomo, imported.format)
+        assertEquals(1, imported.connectionCount)
+        assertEquals(source, imported.yaml)
     }
 
     @Test

--- a/app/src/test/java/com/whitedns/vpn/VpnServicePolicyTest.kt
+++ b/app/src/test/java/com/whitedns/vpn/VpnServicePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.whitedns.vpn
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -8,6 +9,126 @@ import org.junit.Test
 import java.io.IOException
 
 class VpnServicePolicyTest {
+    @Test
+    fun builtInAutomaticConnectionsTryPrivateThenPublic() {
+        assertEquals(
+            listOf(
+                SubscriptionStore.PRIVATE_SUBSCRIPTION_ID,
+                SubscriptionStore.PUBLIC_SUBSCRIPTION_ID,
+            ),
+            BuiltInSubscriptionStartupPolicy.sourceIds(
+                SubscriptionStore.PUBLIC_SUBSCRIPTION_ID,
+                explicitProfile = null,
+            ),
+        )
+        assertEquals(
+            listOf("custom"),
+            BuiltInSubscriptionStartupPolicy.sourceIds("custom", explicitProfile = null),
+        )
+
+        val explicit = ConnectionProfile(
+            tag = "Explicit",
+            type = "vless",
+            server = "example.com",
+            port = 443,
+            transport = "tcp",
+            validationHost = "example.com",
+            fingerprint = "explicit",
+            outboundJson = "{}",
+        )
+        assertEquals(
+            listOf(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID),
+            BuiltInSubscriptionStartupPolicy.sourceIds(
+                SubscriptionStore.PUBLIC_SUBSCRIPTION_ID,
+                explicit,
+            ),
+        )
+    }
+
+    @Test
+    fun builtInFallbackOnlyConsumesOrdinaryIoFailures() {
+        assertTrue(BuiltInSubscriptionStartupPolicy.canFallback(IOException("unavailable")))
+        assertFalse(BuiltInSubscriptionStartupPolicy.canFallback(CancellationException("canceled")))
+        assertFalse(BuiltInSubscriptionStartupPolicy.canFallback(MihomoCoreBusyException()))
+        assertFalse(BuiltInSubscriptionStartupPolicy.canFallback(MihomoCoreSetupTimeoutException()))
+    }
+
+    @Test
+    fun builtInFallbackStopsAtTheFirstSuccessAndPropagatesTerminalFailures() = runBlocking {
+        val attempts = mutableListOf<String>()
+        assertEquals(
+            "private connected",
+            BuiltInSubscriptionStartupPolicy.firstSuccessful(
+                SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS,
+            ) { sourceId ->
+                attempts += sourceId
+                "private connected"
+            },
+        )
+        assertEquals(listOf(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID), attempts)
+
+        attempts.clear()
+        val result = BuiltInSubscriptionStartupPolicy.firstSuccessful(
+            SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS,
+        ) { sourceId ->
+            attempts += sourceId
+            if (sourceId == SubscriptionStore.PRIVATE_SUBSCRIPTION_ID) {
+                throw IOException("private unavailable")
+            }
+            "public connected"
+        }
+        assertEquals("public connected", result)
+        assertEquals(SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS, attempts)
+
+        val terminal = runCatching {
+            BuiltInSubscriptionStartupPolicy.firstSuccessful(
+                SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS,
+            ) { throw IOException(it) }
+        }.exceptionOrNull()
+        assertEquals(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID, terminal?.message)
+
+        attempts.clear()
+        val canceled = runCatching {
+            BuiltInSubscriptionStartupPolicy.firstSuccessful(
+                SubscriptionStore.BUILT_IN_SUBSCRIPTION_IDS,
+            ) { sourceId ->
+                attempts += sourceId
+                throw CancellationException("canceled")
+            }
+        }.exceptionOrNull()
+        assertTrue(canceled is CancellationException)
+        assertEquals(listOf(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID), attempts)
+    }
+
+    @Test
+    fun publicRuntimeUsesPublicConnectionNotice() {
+        assertEquals(
+            R.string.notification_connected_public,
+            connectedNotificationTextRes(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID),
+        )
+        assertEquals(
+            R.string.notification_connected,
+            connectedNotificationTextRes(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID),
+        )
+    }
+
+    @Test
+    fun recoveryExclusionsApplyOnlyToTheirRuntimeSource() {
+        val exclusion = ConnectionStartupExclusion(
+            subscriptionId = SubscriptionStore.PUBLIC_SUBSCRIPTION_ID,
+            profileFingerprint = "public-profile",
+        )
+
+        assertEquals(
+            "public-profile",
+            exclusion.forSubscription(SubscriptionStore.PUBLIC_SUBSCRIPTION_ID).profileFingerprint,
+        )
+        assertEquals(
+            "",
+            exclusion.forSubscription(SubscriptionStore.PRIVATE_SUBSCRIPTION_ID).profileFingerprint,
+        )
+    }
+
     @Test
     fun systemStartedServiceConnectsWhileAppActionsStayExplicit() {
         assertEquals(Actions.CONNECT, Actions.resolveServiceAction(null, appInitiated = false))

--- a/app/src/test/java/com/whitedns/vpn/WhiteDnsConfigTest.kt
+++ b/app/src/test/java/com/whitedns/vpn/WhiteDnsConfigTest.kt
@@ -14,6 +14,10 @@ class WhiteDnsConfigTest {
     @Test
     fun subscriptionUrlComesFromBuildTimeConfiguration() {
         assertEquals(BuildConfig.MIHOMO_SUBSCRIPTION_URL, WhiteDnsConfig.MIHOMO_SUBSCRIPTION_URL)
+        assertEquals(
+            BuildConfig.PRIVATE_MIHOMO_SUBSCRIPTION_URL,
+            WhiteDnsConfig.PRIVATE_MIHOMO_SUBSCRIPTION_URL,
+        )
     }
 
     @Test

--- a/scripts/build-flclash-core.sh
+++ b/scripts/build-flclash-core.sh
@@ -4,13 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOURCE_FLCLASH_DIR="${FLCLASH_DIR:-${ROOT_DIR}/FlClash}"
 FLCLASH_REPOSITORY="https://github.com/chen08209/FlClash.git"
+MIHOMO_REPOSITORY="https://github.com/MetaCubeX/mihomo.git"
 FLCLASH_COMMIT="ac2f6b919ec1ad395b61b4bb1e714a39c750babe"
-MIHOMO_COMMIT="7bdcd60da9db10b681d7507af96d4fad797f3774"
-MIHOMO_VERSION="v1.19.25-1-g7bdcd60"
+FLCLASH_PATCH="${ROOT_DIR}/scripts/patches/flclash-v1.19.30.patch"
+MIHOMO_PATCH="${ROOT_DIR}/scripts/patches/mihomo-v1.19.30-flclash.patch"
+MIHOMO_COMMIT="ac017cdd246ce8bd547653d927e7bf77d7ee73d5"
+MIHOMO_VERSION="v1.19.30"
 OUT_JNI_DIR="${ROOT_DIR}/app/src/main/jniLibs"
 OUT_INCLUDE_DIR="${ROOT_DIR}/app/src/main/cpp/includes"
 VERSION_FILE="${OUT_JNI_DIR}/.mihomo-version"
-CORE_BUILD_ID="${FLCLASH_COMMIT}-${MIHOMO_COMMIT}"
+CORE_BUILD_ID="${FLCLASH_COMMIT}-${MIHOMO_COMMIT}-whitedns-awg3"
 API_LEVEL="${ANDROID_API_LEVEL:-26}"
 ABIS=("armeabi-v7a" "arm64-v8a" "x86" "x86_64")
 
@@ -62,22 +65,71 @@ SOURCE_SUBMODULE_DIR="${SOURCE_FLCLASH_DIR}/core/Clash.Meta"
 git clone --no-hardlinks --no-checkout "${SOURCE_FLCLASH_DIR}" "${FLCLASH_DIR}"
 git -C "${FLCLASH_DIR}" checkout --detach "${FLCLASH_COMMIT}"
 
+if ! git -C "${FLCLASH_DIR}" apply --check "${FLCLASH_PATCH}"; then
+  echo "Unable to apply the pinned FlClash v1.19.30 compatibility patch." >&2
+  exit 1
+fi
+git -C "${FLCLASH_DIR}" apply "${FLCLASH_PATCH}"
+
 rm -rf "${SUBMODULE_DIR}"
 if git -C "${SOURCE_SUBMODULE_DIR}" rev-parse --git-dir >/dev/null 2>&1 &&
   git -C "${SOURCE_SUBMODULE_DIR}" cat-file -e "${MIHOMO_COMMIT}^{commit}" 2>/dev/null; then
   git clone --no-hardlinks --no-checkout "${SOURCE_SUBMODULE_DIR}" "${SUBMODULE_DIR}"
   git -C "${SUBMODULE_DIR}" checkout --detach "${MIHOMO_COMMIT}"
 else
-  echo "Fetching FlClash's pinned Mihomo commit..."
-  git -C "${FLCLASH_DIR}" submodule set-url \
-    core/Clash.Meta https://github.com/chen08209/Clash.Meta.git
-  git -C "${FLCLASH_DIR}" submodule update --init --depth 1 core/Clash.Meta
+  echo "Fetching pinned Mihomo ${MIHOMO_VERSION} source..."
+  mkdir -p "${SUBMODULE_DIR}"
+  git -C "${SUBMODULE_DIR}" init
+  git -C "${SUBMODULE_DIR}" remote add origin "${MIHOMO_REPOSITORY}"
+  git -C "${SUBMODULE_DIR}" fetch --depth 1 origin "${MIHOMO_COMMIT}"
+  git -C "${SUBMODULE_DIR}" checkout --detach "${MIHOMO_COMMIT}"
 fi
 
 if [[ "$(git -C "${SUBMODULE_DIR}" rev-parse HEAD)" != "${MIHOMO_COMMIT}" ]]; then
   echo "FlClash Mihomo checkout must be pinned to ${MIHOMO_COMMIT}: ${SUBMODULE_DIR}" >&2
   exit 1
 fi
+
+if ! git -C "${SUBMODULE_DIR}" apply --check "${MIHOMO_PATCH}"; then
+  echo "Unable to apply the pinned Mihomo AWG3 and FlClash compatibility patch." >&2
+  exit 1
+fi
+git -C "${SUBMODULE_DIR}" apply "${MIHOMO_PATCH}"
+
+validate_amnezia_v3_support() {
+  local wireguard_source="${SUBMODULE_DIR}/adapter/outbound/wireguard.go"
+  local marker
+  local markers=(
+    'Version int `proxy:"version,omitempty"`'
+    'HeaderProtectionKey'
+    'ContentPaddingAddition'
+    'RekeyAfterTime'
+    'RekeyTimeout'
+    'RejectAfterTime'
+    'KeepaliveTimeout'
+    'MaxHandshakeAttempts'
+    'RandomTrailers'
+    'DisableCookies'
+    'amneziav3.NewDevice'
+    'header_protection_key='
+    'content_padding_addition='
+    'rekey_after_time='
+    'rekey_timeout='
+    'reject_after_time='
+    'keepalive_timeout='
+    'max_handshake_attempts='
+    'random_trailers=1'
+    'disable_cookies=1'
+  )
+  for marker in "${markers[@]}"; do
+    if ! grep -Fq "${marker}" "${wireguard_source}"; then
+      echo "Pinned Mihomo core lacks AmneziaWG v3 support marker: ${marker}" >&2
+      exit 1
+    fi
+  done
+}
+
+validate_amnezia_v3_support
 
 if ! command -v go >/dev/null 2>&1; then
   echo "Go is required to build the FlClash Mihomo core." >&2
@@ -175,6 +227,7 @@ build_abi() {
       GOOS=android \
       GOARCH="${goarch}" \
       ${goarm:+GOARM="${goarm}"} \
+      GOCACHE="${BUILD_TMP_DIR}/go-build-cache" \
       CGO_ENABLED=1 \
       CC="${cc}" \
       CFLAGS="-O3 -Werror" \

--- a/scripts/patches/flclash-v1.19.30.patch
+++ b/scripts/patches/flclash-v1.19.30.patch
@@ -1,0 +1,643 @@
+diff --git a/core/Clash.Meta b/core/Clash.Meta
+index 7bdcd60da9db10b681d7507af96d4fad797f3774..d40457d92f0d9a8d1383262f8a0438cf7d490d59 160000
+--- a/core/Clash.Meta
++++ b/core/Clash.Meta
+@@ -1 +1 @@
+-Subproject commit 7bdcd60da9db10b681d7507af96d4fad797f3774
++Subproject commit d40457d92f0d9a8d1383262f8a0438cf7d490d59
+diff --git a/core/action.go b/core/action.go
+index 41a3b680b269308a247c37d86c6b14f5c2e7f54d..a7d6c8f9179c6bf051680c97df4363b4fc77f390 100644
+--- a/core/action.go
++++ b/core/action.go
+@@ -129,19 +129,11 @@ func handleAction(action *Action, result ActionResult) {
+ 	case getExternalProviderMethod:
+ 		externalProviderName := action.Data.(string)
+ 		result.success(handleGetExternalProvider(externalProviderName))
++		return
+ 	case updateGeoDataMethod:
+-		paramsString := action.Data.(string)
+-		var params = map[string]string{}
+-		err := json.Unmarshal([]byte(paramsString), &params)
+-		if err != nil {
+-			result.success(err.Error())
+-			return
+-		}
+-		geoType := params["geo-type"]
+-		geoName := params["geo-name"]
+-		handleUpdateGeoData(geoType, geoName, func(value string) {
+-			result.success(value)
+-		})
++		geoType := action.Data.(string)
++		handleUpdateGeoData(geoType)
++		result.success("")
+ 		return
+ 	case updateExternalProviderMethod:
+ 		providerName := action.Data.(string)
+diff --git a/core/common.go b/core/common.go
+index bdde7616e760e76c3336c687b5d1d183012e3678..2f71417992f8190e133ac422af230633053057a6 100644
+--- a/core/common.go
++++ b/core/common.go
+@@ -13,6 +13,7 @@ import (
+ 	"github.com/metacubex/mihomo/common/batch"
+ 	"github.com/metacubex/mihomo/component/dialer"
+ 	"github.com/metacubex/mihomo/component/resolver"
++	"github.com/metacubex/mihomo/component/updater"
+ 	"github.com/metacubex/mihomo/config"
+ 	"github.com/metacubex/mihomo/constant"
+ 	"github.com/metacubex/mihomo/constant/features"
+@@ -234,7 +235,17 @@ func updateConfig(params *UpdateParams) {
+ 		general.Tun.Stack = *params.Tun.Stack
+ 	}
+ 
++	if params.GeoAutoUpdate != nil {
++		updater.SetGeoAutoUpdate(*params.GeoAutoUpdate)
++	}
++	if params.GeoUpdateInterval != nil {
++		updater.SetGeoUpdateInterval(*params.GeoUpdateInterval)
++	}
++
+ 	updateListeners()
++	if updater.GeoAutoUpdate() {
++		updater.RegisterGeoUpdaterWithCancel()
++	}
+ }
+ 
+ func applyConfig(params *SetupParams) error {
+@@ -250,6 +261,9 @@ func applyConfig(params *SetupParams) error {
+ 	hub.ApplyConfig(currentConfig)
+ 	patchSelectGroup(params.SelectedMap)
+ 	updateListeners()
++	if updater.GeoAutoUpdate() {
++		updater.RegisterGeoUpdaterWithCancel()
++	}
+ 	return err
+ }
+ 
+diff --git a/core/constant.go b/core/constant.go
+index 5177fe4cff3671f3628a1d3055a1871706b002f1..ed16fea2ebfdf5b24906d66946aeb42ceded926e 100644
+--- a/core/constant.go
++++ b/core/constant.go
+@@ -34,6 +34,8 @@ type UpdateParams struct {
+ 	ExternalController *string            `json:"external-controller"`
+ 	Interface          *string            `json:"interface-name"`
+ 	UnifiedDelay       *bool              `json:"unified-delay"`
++	GeoAutoUpdate      *bool              `json:"geo-auto-update"`
++	GeoUpdateInterval  *int               `json:"geo-update-interval"`
+ }
+ 
+ type tunSchema struct {
+@@ -123,12 +125,20 @@ type Message struct {
+ }
+ 
+ const (
+-	LogMessage     MessageType = "log"
+-	DelayMessage   MessageType = "delay"
+-	RequestMessage MessageType = "request"
+-	LoadedMessage  MessageType = "loaded"
++	LogMessage       MessageType = "log"
++	DelayMessage     MessageType = "delay"
++	RequestMessage   MessageType = "request"
++	LoadedMessage    MessageType = "loaded"
++	GeoUpdateMessage MessageType = "geoUpdate"
+ )
+ 
++type GeoUpdateStatus struct {
++	Type     string `json:"type"`
++	Updating bool   `json:"updating"`
++	Skipped  bool   `json:"skipped,omitempty"`
++	Error    string `json:"error,omitempty"`
++}
++
+ func (message *Message) Json() (string, error) {
+ 	data, err := json.Marshal(message)
+ 	return string(data), err
+diff --git a/core/go.mod b/core/go.mod
+index fd55718576f9eda0c1880cda5ccccdd3ccd7fc31..11c83fce39359df240bf3d781e3deb6b424c3e04 100644
+--- a/core/go.mod
++++ b/core/go.mod
+@@ -14,16 +14,17 @@ require (
+ require (
+ 	github.com/RyuaNerin/go-krypto v1.3.0 // indirect
+ 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344 // indirect
+-	github.com/ajg/form v1.5.1 // indirect
++	github.com/ajg/form v1.7.1 // indirect
+ 	github.com/akutz/memconn v0.1.0 // indirect
+-	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
+-	github.com/andybalholm/brotli v1.0.6 // indirect
++	github.com/andybalholm/brotli v1.1.1 // indirect
+ 	github.com/bahlo/generic-list-go v0.2.0 // indirect
++	github.com/bodgit/plumbing v1.3.0 // indirect
++	github.com/bodgit/windows v1.0.1 // indirect
+ 	github.com/coder/websocket v1.8.12 // indirect
+ 	github.com/coreos/go-iptables v0.8.0 // indirect
+ 	github.com/dlclark/regexp2 v1.12.0 // indirect
+ 	github.com/dunglas/httpsfv v1.0.2 // indirect
+-	github.com/enfein/mieru/v3 v3.31.0 // indirect
++	github.com/enfein/mieru/v3 v3.35.0 // indirect
+ 	github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 // indirect
+ 	github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 // indirect
+ 	github.com/ericlagergren/siv v0.0.0-20220507050439-0b757b3aa5f1 // indirect
+@@ -35,14 +36,13 @@ require (
+ 	github.com/gobwas/httphead v0.1.0 // indirect
+ 	github.com/gobwas/pool v0.2.1 // indirect
+ 	github.com/gobwas/ws v1.4.0 // indirect
+-	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
+ 	github.com/gofrs/uuid/v5 v5.4.0 // indirect
+ 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+ 	github.com/golang/snappy v1.0.0 // indirect
+ 	github.com/google/btree v1.1.3 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
+-	github.com/huin/goupnp v1.3.0 // indirect
++	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+ 	github.com/insomniacslk/dhcp v0.0.0-20250109001534-8abf58130905 // indirect
+ 	github.com/josharian/native v1.1.0 // indirect
+ 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
+@@ -51,57 +51,63 @@ require (
+ 	github.com/klauspost/reedsolomon v1.12.3 // indirect
+ 	github.com/mdlayher/netlink v1.7.2 // indirect
+ 	github.com/mdlayher/socket v0.5.1 // indirect
+-	github.com/metacubex/amneziawg-go v0.0.0-20251104174305-5a0e9f7e361d // indirect
++	github.com/metacubex/age v0.0.0-20260603010618-28d156b4ea78 // indirect
++	github.com/metacubex/amneziawg-go v0.0.0-20260816073447-736a78668832 // indirect
+ 	github.com/metacubex/ascon v0.1.0 // indirect
+-	github.com/metacubex/bart v0.26.0 // indirect
+-	github.com/metacubex/bbolt v0.0.0-20250725135710-010dbbbb7a5b // indirect
++	github.com/metacubex/bart v0.29.0 // indirect
++	github.com/metacubex/bbolt v0.0.0-20260706163408-d4ec34ad7c48 // indirect
+ 	github.com/metacubex/blake3 v0.1.0 // indirect
+ 	github.com/metacubex/chacha v0.1.5 // indirect
+-	github.com/metacubex/chi v0.1.0 // indirect
+-	github.com/metacubex/connect-ip-go v0.0.0-20260412152424-e1625567920a // indirect
++	github.com/metacubex/chi v0.1.1 // indirect
++	github.com/metacubex/connect-ip-go v0.0.0-20260727083417-67ccdb0cf771 // indirect
+ 	github.com/metacubex/cpu v0.1.1 // indirect
+ 	github.com/metacubex/edwards25519 v1.2.0 // indirect
+ 	github.com/metacubex/fswatch v0.1.1 // indirect
+ 	github.com/metacubex/gopacket v1.1.20-0.20230608035415-7e2f98a3e759 // indirect
+-	github.com/metacubex/gvisor v0.0.0-20251227095601-261ec1326fe8 // indirect
++	github.com/metacubex/gvisor v0.0.0-20260810011720-3cc44cf9ac22 // indirect
+ 	github.com/metacubex/hkdf v0.1.0 // indirect
+ 	github.com/metacubex/hpke v0.1.0 // indirect
+-	github.com/metacubex/http v0.1.6 // indirect
+-	github.com/metacubex/jsonv2 v0.0.0-20260513175203-1c6abea7534c // indirect
++	github.com/metacubex/http v0.1.7 // indirect
++	github.com/metacubex/jls-quic-go v0.0.0-20260727080412-732f2fc9a34d // indirect
++	github.com/metacubex/jls-tls v0.0.0-20260723084315-67adc0e2f796 // indirect
++	github.com/metacubex/jsonv2 v0.0.0-20260721082349-16b4998c8f89 // indirect
+ 	github.com/metacubex/kcp-go v0.0.0-20260105040817-550693377604 // indirect
+ 	github.com/metacubex/mhurl v0.1.0 // indirect
++	github.com/metacubex/mipstack v0.0.0-20260816065001-b7038299fe13 // indirect
+ 	github.com/metacubex/mlkem v0.1.0 // indirect
+ 	github.com/metacubex/nftables v0.0.0-20260426003805-208c2c1ba2cb // indirect
+ 	github.com/metacubex/qpack v0.6.0 // indirect
+-	github.com/metacubex/quic-go v0.59.1-0.20260413153657-53bb22f2c306 // indirect
++	github.com/metacubex/quic-go v0.61.1-0.20260727080200-2548683b76f4 // indirect
+ 	github.com/metacubex/randv2 v0.2.0 // indirect
+-	github.com/metacubex/restls-client-go v0.1.7 // indirect
++	github.com/metacubex/restls-client-go v0.1.9 // indirect
++	github.com/metacubex/sevenzip v1.6.4 // indirect
+ 	github.com/metacubex/sing v0.5.7 // indirect
+-	github.com/metacubex/sing-mux v0.3.9 // indirect
+-	github.com/metacubex/sing-quic v0.0.0-20260512151354-8475655be853 // indirect
++	github.com/metacubex/sing-mux v0.3.10 // indirect
++	github.com/metacubex/sing-quic v0.0.0-20260726014900-38b0e9295f51 // indirect
+ 	github.com/metacubex/sing-shadowsocks v0.2.12 // indirect
+ 	github.com/metacubex/sing-shadowsocks2 v0.2.7 // indirect
+-	github.com/metacubex/sing-shadowtls v0.0.0-20250503063515-5d9f966d17a2 // indirect
+-	github.com/metacubex/sing-tun v0.4.18 // indirect
++	github.com/metacubex/sing-tun v0.4.22 // indirect
+ 	github.com/metacubex/sing-vmess v0.2.5 // indirect
+-	github.com/metacubex/sing-wireguard v0.0.0-20260507084707-690d479ec947 // indirect
++	github.com/metacubex/sing-wireguard v0.0.0-20260810013230-110eac03c3f0 // indirect
+ 	github.com/metacubex/smux v0.0.0-20260105030934-d0c8756d3141 // indirect
+ 	github.com/metacubex/ssh v0.1.0 // indirect
+-	github.com/metacubex/tailscale v0.0.0-20260516120020-a21c2c99dcbe // indirect
+-	github.com/metacubex/tailscale-wireguard-go v0.0.0-20260513233728-8bc7ee255d04 // indirect
+-	github.com/metacubex/tfo-go v0.0.0-20251130171125-413e892ac443 // indirect
+-	github.com/metacubex/tls v0.1.5 // indirect
+-	github.com/metacubex/utls v1.8.4 // indirect
++	github.com/metacubex/tailscale v0.0.0-20260807072706-a4fb5feabcbb // indirect
++	github.com/metacubex/tailscale-wireguard-go v0.0.0-20260725073821-e61ab99cede2 // indirect
++	github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c // indirect
++	github.com/metacubex/tls v0.1.8 // indirect
++	github.com/metacubex/utls v1.8.7 // indirect
+ 	github.com/metacubex/wireguard-go v0.0.0-20250820062549-a6cecdd7f57f // indirect
+ 	github.com/metacubex/yamux v0.0.0-20250918083631-dd5f17c0be49 // indirect
++	github.com/metacubex/zerotier-go v0.0.0-20260813124750-13fa6f45da5f // indirect
+ 	github.com/miekg/dns v1.1.63 // indirect
+ 	github.com/mitchellh/go-ps v1.0.0 // indirect
+ 	github.com/mroth/weightedrand/v2 v2.1.0 // indirect
+ 	github.com/oasisprotocol/deoxysii v0.0.0-20220228165953-2091330c22b7 // indirect
+ 	github.com/openacid/low v0.1.21 // indirect
+ 	github.com/oschwald/maxminddb-golang v1.12.0 // indirect
+-	github.com/pierrec/lz4/v4 v4.1.14 // indirect
++	github.com/pierrec/lz4/v4 v4.1.27 // indirect
+ 	github.com/pires/go-proxyproto v0.8.0 // indirect
++	github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e // indirect
+ 	github.com/safchain/ethtool v0.3.0 // indirect
+ 	github.com/sagernet/netlink v0.0.0-20240612041022-b9a21c07ac6a // indirect
+ 	github.com/samber/lo v1.53.0 // indirect
+@@ -109,11 +115,13 @@ require (
+ 	github.com/sina-ghaderi/rabaead v0.0.0-20220730151906-ab6e06b96e8c // indirect
+ 	github.com/sina-ghaderi/rabbitio v0.0.0-20220730151941-9ce26f4f872e // indirect
+ 	github.com/sirupsen/logrus v1.9.4 // indirect
++	github.com/stangelandcl/ppmd v0.1.1 // indirect
+ 	github.com/tailscale/certstore v0.1.1-0.20260409135935-3638fb84b77d // indirect
+ 	github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55 // indirect
+ 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a // indirect
+ 	github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc // indirect
+ 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect
++	github.com/ulikunitz/xz v0.5.15 // indirect
+ 	github.com/vishvananda/netns v0.0.5 // indirect
+ 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+ 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+@@ -126,7 +134,6 @@ require (
+ 	golang.org/x/crypto v0.33.0 // indirect
+ 	golang.org/x/mod v0.20.0 // indirect
+ 	golang.org/x/net v0.35.0 // indirect
+-	golang.org/x/oauth2 v0.24.0 // indirect
+ 	golang.org/x/sys v0.30.0 // indirect
+ 	golang.org/x/term v0.29.0 // indirect
+ 	golang.org/x/text v0.22.0 // indirect
+diff --git a/core/go.sum b/core/go.sum
+index c63494ac41f77952f0b9b3606a7dd58dcb4da511..fefb4d23184fd4ade14c8b18f5a3a343ec93e925 100644
+--- a/core/go.sum
++++ b/core/go.sum
+@@ -6,17 +6,19 @@ github.com/RyuaNerin/testingutil v0.1.0 h1:IYT6JL57RV3U2ml3dLHZsVtPOP6yNK7WUVdzz
+ github.com/RyuaNerin/testingutil v0.1.0/go.mod h1:yTqj6Ta/ycHMPJHRyO12Mz3VrvTloWOsy23WOZH19AA=
+ github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344 h1:cDVUiFo+npB0ZASqnw4q90ylaVAbnYyx0JYqK4YcGok=
+ github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344/go.mod h1:9pIqrY6SXNL8vjRQE5Hd/OL5GyK/9MrGUWs87z/eFfk=
+-github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+-github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
++github.com/ajg/form v1.7.1 h1:OsnBDzTkrWdrxvEnO68I72ZVGJGNaMwPhoAm0V+llgc=
++github.com/ajg/form v1.7.1/go.mod h1:HL757PzLyNkj5AIfptT6L+iGNeXTlnrr/oDePGc/y7Q=
+ github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=
+ github.com/akutz/memconn v0.1.0/go.mod h1:Jo8rI7m0NieZyLI5e2CDlRdRqRRB4S7Xp77ukDjH+Fw=
+-github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
+-github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+-github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
+-github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
++github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
++github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+ github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
++github.com/bodgit/plumbing v1.3.0 h1:pf9Itz1JOQgn7vEOE7v7nlEfBykYqvUYioC61TwWCFU=
++github.com/bodgit/plumbing v1.3.0/go.mod h1:JOTb4XiRu5xfnmdnDJo6GmSbSbtSyufrsyZFByMtKEs=
++github.com/bodgit/windows v1.0.1 h1:tF7K6KOluPYygXa3Z2594zxlkbKPAOvqr97etrGNIz4=
++github.com/bodgit/windows v1.0.1/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
+ github.com/cilium/ebpf v0.12.3 h1:8ht6F9MquybnY97at+VDZb3eQQr8ev79RueWeVaEcG4=
+ github.com/cilium/ebpf v0.12.3/go.mod h1:TctK1ivibvI3znr66ljgi4hqOT8EYQjz1KWBfb1UVgM=
+ github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+@@ -30,8 +32,8 @@ github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz
+ github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+ github.com/dunglas/httpsfv v1.0.2 h1:iERDp/YAfnojSDJ7PW3dj1AReJz4MrwbECSSE59JWL0=
+ github.com/dunglas/httpsfv v1.0.2/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
+-github.com/enfein/mieru/v3 v3.31.0 h1:Fl2ocRCRXJzMygzdRjBHgqI996ZuIDHUmyQyovSf9sA=
+-github.com/enfein/mieru/v3 v3.31.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
++github.com/enfein/mieru/v3 v3.35.0 h1:AKQT6l9R6xcYaUocpfjqE/vWEvYMxpl+071bhfDXkMY=
++github.com/enfein/mieru/v3 v3.35.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+ github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
+ github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
+ github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=
+@@ -42,6 +44,8 @@ github.com/ericlagergren/siv v0.0.0-20220507050439-0b757b3aa5f1 h1:tlDMEdcPRQKBE
+ github.com/ericlagergren/siv v0.0.0-20220507050439-0b757b3aa5f1/go.mod h1:4RfsapbGx2j/vU5xC/5/9qB3kn9Awp1YDiEnN43QrJ4=
+ github.com/ericlagergren/subtle v0.0.0-20220507045147-890d697da010 h1:fuGucgPk5dN6wzfnxl3D0D3rVLw4v2SbBT9jb4VnxzA=
+ github.com/ericlagergren/subtle v0.0.0-20220507045147-890d697da010/go.mod h1:JtBcj7sBuTTRupn7c2bFspMDIObMJsVK8TeUvpShPok=
++github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
++github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+@@ -58,8 +62,6 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
+ github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+ github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
+ github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
+-github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 h1:sQspH8M4niEijh3PFscJRLDnkL547IeP7kpPe3uUhEg=
+-github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466/go.mod h1:ZiQxhyQ+bbbfxUKVvjfO498oPYvtYhZzycal3G/NHmU=
+ github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
+ github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
+ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+@@ -75,8 +77,8 @@ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQu
+ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
+ github.com/google/tink/go v1.6.1 h1:t7JHqO8Ath2w2ig5vjwQYJzhGEZymedQc90lQXUBa4I=
+ github.com/google/tink/go v1.6.1/go.mod h1:IGW53kTgag+st5yPhKKwJ6u2l+SSp5/v9XF7spovjlY=
+-github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
+-github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
++github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
++github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+ github.com/insomniacslk/dhcp v0.0.0-20250109001534-8abf58130905 h1:q3OEI9RaN/wwcx+qgGo6ZaoJkCiDYe/gjDLfq7lQQF4=
+ github.com/insomniacslk/dhcp v0.0.0-20250109001534-8abf58130905/go.mod h1:VvGYjkZoJyKqlmT1yzakUs4mfKMNB0XdODP0+rdml6k=
+ github.com/josharian/native v1.0.1-0.20221213033349-c1e37c09b531/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
+@@ -90,26 +92,32 @@ github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/4
+ github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+ github.com/klauspost/reedsolomon v1.12.3 h1:tzUznbfc3OFwJaTebv/QdhnFf2Xvb7gZ24XaHLBPmdc=
+ github.com/klauspost/reedsolomon v1.12.3/go.mod h1:3K5rXwABAvzGeR01r6pWZieUALXO/Tq7bFKGIb4m4WI=
++github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
++github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
++github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
++github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
+ github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
+ github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
+ github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
+-github.com/metacubex/amneziawg-go v0.0.0-20251104174305-5a0e9f7e361d h1:vAJ0ZT4aO803F1uw2roIA9yH7Sxzox34tVVyye1bz6c=
+-github.com/metacubex/amneziawg-go v0.0.0-20251104174305-5a0e9f7e361d/go.mod h1:MsM/5czONyXMJ3PRr5DbQ4O/BxzAnJWOIcJdLzW6qHY=
++github.com/metacubex/age v0.0.0-20260603010618-28d156b4ea78 h1:LqWr0vb9zDNuQS+jJd4fnRYk/SEI7KJ7TDe/L4WFK48=
++github.com/metacubex/age v0.0.0-20260603010618-28d156b4ea78/go.mod h1:BTBG/iVY7rg3qq5WdVCg0GFk58CSvCDSbjy8I7kEx/c=
++github.com/metacubex/amneziawg-go v0.0.0-20260816073447-736a78668832 h1:mAIVFc8Z9jziImzNl5bXUBVU2bTEmP2sXfosn/6YxPs=
++github.com/metacubex/amneziawg-go v0.0.0-20260816073447-736a78668832/go.mod h1:MsM/5czONyXMJ3PRr5DbQ4O/BxzAnJWOIcJdLzW6qHY=
+ github.com/metacubex/ascon v0.1.0 h1:6ZWxmXYszT1XXtwkf6nxfFhc/OTtQ9R3Vyj1jN32lGM=
+ github.com/metacubex/ascon v0.1.0/go.mod h1:eV5oim4cVPPdEL8/EYaTZ0iIKARH9pnhAK/fcT5Kacc=
+-github.com/metacubex/bart v0.26.0 h1:d/bBTvVatfVWGfQbiDpYKI1bXUJgjaabB2KpK1Tnk6w=
+-github.com/metacubex/bart v0.26.0/go.mod h1:DCcyfP4MC+Zy7sLK7XeGuMw+P5K9mIRsYOBgiE8icsI=
+-github.com/metacubex/bbolt v0.0.0-20250725135710-010dbbbb7a5b h1:j7dadXD8I2KTmMt8jg1JcaP1ANL3JEObJPdANKcSYPY=
+-github.com/metacubex/bbolt v0.0.0-20250725135710-010dbbbb7a5b/go.mod h1:+WmP0VJZDkDszvpa83HzfUp6QzARl/IKkMorH4+nODw=
++github.com/metacubex/bart v0.29.0 h1:yVc/lLdDqn+7FShI0qUghStHl0/d3mn4EH/I5R5niKk=
++github.com/metacubex/bart v0.29.0/go.mod h1:DCcyfP4MC+Zy7sLK7XeGuMw+P5K9mIRsYOBgiE8icsI=
++github.com/metacubex/bbolt v0.0.0-20260706163408-d4ec34ad7c48 h1:D+AoQ7g/ZeZAHAapelrZB0xUNRcDGuoNLcGmHCnC9Ss=
++github.com/metacubex/bbolt v0.0.0-20260706163408-d4ec34ad7c48/go.mod h1:yOfzykxfYIEVOtEys6KOKwxy75M2I/KtOQ+p3Kzc8/k=
+ github.com/metacubex/blake3 v0.1.0 h1:KGnjh/56REO7U+cgZA8dnBhxdP7jByrG7hTP+bu6cqY=
+ github.com/metacubex/blake3 v0.1.0/go.mod h1:CCkLdzFrqf7xmxCdhQFvJsRRV2mwOLDoSPg6vUTB9Uk=
+ github.com/metacubex/chacha v0.1.5 h1:fKWMb/5c7ZrY8Uoqi79PPFxl+qwR7X/q0OrsAubyX2M=
+ github.com/metacubex/chacha v0.1.5/go.mod h1:Djn9bPZxLTXbJFSeyo0/qzEzQI+gUSSzttuzZM75GH8=
+-github.com/metacubex/chi v0.1.0 h1:rjNDyDj50nRpicG43CNkIw4ssiCbmDL8d7wJXKlUCsg=
+-github.com/metacubex/chi v0.1.0/go.mod h1:zM5u5oMQt8b2DjvDHvzadKrP6B2ztmasL1YHRMbVV+g=
+-github.com/metacubex/connect-ip-go v0.0.0-20260412152424-e1625567920a h1:Ph5UfTWDsGruZ+v95Df1ycTflQFmpZBFg2LUvj2kx/M=
+-github.com/metacubex/connect-ip-go v0.0.0-20260412152424-e1625567920a/go.mod h1:xYC8Ik7/rN6no+vTRuWMEziGwm3brA0wNM/zZP9qhOQ=
++github.com/metacubex/chi v0.1.1 h1:GajmCIXSIPAZNxqTTYpkCrkY9suBz9wjIdgPcoQ5K1A=
++github.com/metacubex/chi v0.1.1/go.mod h1:/CvDXe8jZD/ecU8Y7fmS5XKLRR44UDmC6/IBkRIb6Z4=
++github.com/metacubex/connect-ip-go v0.0.0-20260727083417-67ccdb0cf771 h1:nLGBvwQ2vmsD+gU/XWBQH3xaYCM3vQCJIqPfw3mc/L0=
++github.com/metacubex/connect-ip-go v0.0.0-20260727083417-67ccdb0cf771/go.mod h1:9FjDcopUc+tgUva3dauAVzrYPHd0rant+zkvyECzkMg=
+ github.com/metacubex/cpu v0.1.1 h1:rRV5HGmeuGzjiKI3hYbL0dCd0qGwM7VUtk4ICXD06mI=
+ github.com/metacubex/cpu v0.1.1/go.mod h1:09VEt4dSRLR+bOA8l4w4NDuzGZ8n5dkMv7e8axgEeTU=
+ github.com/metacubex/edwards25519 v1.2.0 h1:pIQZLBsjQgg3Nl/c86YYFEUAbL5qQRnPq4LrgIw0KK4=
+@@ -118,68 +126,76 @@ github.com/metacubex/fswatch v0.1.1 h1:jqU7C/v+g0qc2RUFgmAOPoVvfl2BXXUXEumn6oQux
+ github.com/metacubex/fswatch v0.1.1/go.mod h1:czrTT7Zlbz7vWft8RQu9Qqh+JoX+Nnb+UabuyN1YsgI=
+ github.com/metacubex/gopacket v1.1.20-0.20230608035415-7e2f98a3e759 h1:cjd4biTvOzK9ubNCCkQ+ldc4YSH/rILn53l/xGBFHHI=
+ github.com/metacubex/gopacket v1.1.20-0.20230608035415-7e2f98a3e759/go.mod h1:UHOv2xu+RIgLwpXca7TLrXleEd4oR3sPatW6IF8wU88=
+-github.com/metacubex/gvisor v0.0.0-20251227095601-261ec1326fe8 h1:hUL81H0Ic/XIDkvtn9M1pmfDdfid7JzYQToY4Ps1TvQ=
+-github.com/metacubex/gvisor v0.0.0-20251227095601-261ec1326fe8/go.mod h1:8LpS0IJW1VmWzUm3ylb0e2SK5QDm5lO/2qwWLZgRpBU=
++github.com/metacubex/gvisor v0.0.0-20260810011720-3cc44cf9ac22 h1:C4d4/BA8WuQmJnSpjy0UN4vJvRMjU3133rxIYQgbPPs=
++github.com/metacubex/gvisor v0.0.0-20260810011720-3cc44cf9ac22/go.mod h1:mBJW3UXUusd8ZYO5M6mig0uScIey9iIubgdIiQAk2ug=
+ github.com/metacubex/hkdf v0.1.0 h1:fPA6VzXK8cU1foc/TOmGCDmSa7pZbxlnqhl3RNsthaA=
+ github.com/metacubex/hkdf v0.1.0/go.mod h1:3seEfds3smgTAXqUGn+tgEJH3uXdsUjOiduG/2EtvZ4=
+ github.com/metacubex/hpke v0.1.0 h1:gu2jUNhraehWi0P/z5HX2md3d7L1FhPQE6/Q0E9r9xQ=
+ github.com/metacubex/hpke v0.1.0/go.mod h1:vfDm6gfgrwlXUxKDkWbcE44hXtmc1uxLDm2BcR11b3U=
+-github.com/metacubex/http v0.1.6 h1:xvXuvXMCMxCWMF5nEJF4yiKvXL+p2atWMzs37e80m1I=
+-github.com/metacubex/http v0.1.6/go.mod h1:Nxx0zZAo2AhRfanyL+fmmK6ACMtVsfpwIl1aFAik2Eg=
+-github.com/metacubex/jsonv2 v0.0.0-20260513175203-1c6abea7534c h1:KGhBHDe6FveU0ury+9RyX329nclM1CHODa0Fi+uOAYM=
+-github.com/metacubex/jsonv2 v0.0.0-20260513175203-1c6abea7534c/go.mod h1:F4sVXat6QjPXkNsKRDyyG3BhSkxPFFnRPEIwmmyCgbg=
++github.com/metacubex/http v0.1.7 h1:dEaQmijUaR/2QKqgjBUmPZCRuh1zBfDqB6ZRNLwvbHg=
++github.com/metacubex/http v0.1.7/go.mod h1:Nxx0zZAo2AhRfanyL+fmmK6ACMtVsfpwIl1aFAik2Eg=
++github.com/metacubex/jls-quic-go v0.0.0-20260727080412-732f2fc9a34d h1:OF3TUGKdHRrRMp7nb0Pa72QYwKPol9NqSy2yTcP2Sog=
++github.com/metacubex/jls-quic-go v0.0.0-20260727080412-732f2fc9a34d/go.mod h1:dH8StPlpZ7atSUuTnfTnRXvJK22nOtQVimNwQ9Gmk58=
++github.com/metacubex/jls-tls v0.0.0-20260723084315-67adc0e2f796 h1:1iI4np/Dm1ztCfTW2LoN166O6n728HXMc11aIazYdps=
++github.com/metacubex/jls-tls v0.0.0-20260723084315-67adc0e2f796/go.mod h1:mmqs889W/TqPlfNRDa2UyJvRiLyiTJIEnWHkcj3SKB8=
++github.com/metacubex/jsonv2 v0.0.0-20260721082349-16b4998c8f89 h1:v41RWXQbmSD1wqOuoN5VvRHo78wuSziG/bbsLdeH2TQ=
++github.com/metacubex/jsonv2 v0.0.0-20260721082349-16b4998c8f89/go.mod h1:F4sVXat6QjPXkNsKRDyyG3BhSkxPFFnRPEIwmmyCgbg=
+ github.com/metacubex/kcp-go v0.0.0-20260105040817-550693377604 h1:hJwCVlE3ojViC35MGHB+FBr8TuIf3BUFn2EQ1VIamsI=
+ github.com/metacubex/kcp-go v0.0.0-20260105040817-550693377604/go.mod h1:lpmN3m269b3V5jFCWtffqBLS4U3QQoIid9ugtO+OhVc=
+ github.com/metacubex/mhurl v0.1.0 h1:ZdW4Zxe3j3uJ89gNytOazHu6kbHn5owutN/VfXOI8GE=
+ github.com/metacubex/mhurl v0.1.0/go.mod h1:2qpQImCbXoUs6GwJrjuEXKelPyoimsIXr07eNKZdS00=
++github.com/metacubex/mipstack v0.0.0-20260816065001-b7038299fe13 h1:aOU4avd9u7uFivubzn+SjFmEDWAkGF+gvZ0ecEdeg64=
++github.com/metacubex/mipstack v0.0.0-20260816065001-b7038299fe13/go.mod h1:+bbwALZI0pbi2auSG5A3ptdpV2DZ2eLObziXo+P7oj0=
+ github.com/metacubex/mlkem v0.1.0 h1:wFClitonSFcmipzzQvax75beLQU+D7JuC+VK1RzSL8I=
+ github.com/metacubex/mlkem v0.1.0/go.mod h1:amhaXZVeYNShuy9BILcR7P0gbeo/QLZsnqCdL8U2PDQ=
+ github.com/metacubex/nftables v0.0.0-20260426003805-208c2c1ba2cb h1:wk6mHYPURSUvWcUv72gNP79oiylFsscBSDPJ6ieV6Iw=
+ github.com/metacubex/nftables v0.0.0-20260426003805-208c2c1ba2cb/go.mod h1:73ZrCfhdkW4F2E2GAlta3km/S2RHhFNogCMtWZV2anQ=
+ github.com/metacubex/qpack v0.6.0 h1:YqClGIMOpiRYLjV1qOs483Od08MdPgRnHjt90FuaAKw=
+ github.com/metacubex/qpack v0.6.0/go.mod h1:lKGSi7Xk94IMvHGOmxS9eIei3bvIqpOAImEBsaOwTkA=
+-github.com/metacubex/quic-go v0.59.1-0.20260413153657-53bb22f2c306 h1:HlGLmLsWJMLSu0CMI9z/BmEnithB4oXM5Rom6/0Qxtg=
+-github.com/metacubex/quic-go v0.59.1-0.20260413153657-53bb22f2c306/go.mod h1:oNzMrmylS897M3zSMuapIdwSwfq6F2qW01Z3NhVRJhk=
++github.com/metacubex/quic-go v0.61.1-0.20260727080200-2548683b76f4 h1:7oX6CpHVqoUXNyyt0MTuO5ywd1qVe1S1t3jXWMW7bYc=
++github.com/metacubex/quic-go v0.61.1-0.20260727080200-2548683b76f4/go.mod h1:KTmibo7vZo0gCxdFWrPEQ/u/RGt92mJkrXDE2Qg2/AU=
+ github.com/metacubex/randv2 v0.2.0 h1:uP38uBvV2SxYfLj53kuvAjbND4RUDfFJjwr4UigMiLs=
+ github.com/metacubex/randv2 v0.2.0/go.mod h1:kFi2SzrQ5WuneuoLLCMkABtiBu6VRrMrWFqSPyj2cxY=
+-github.com/metacubex/restls-client-go v0.1.7 h1:eCwiXCTQb5WJu9IlgYvDBA1OgrINv58dEe7hcN5H15k=
+-github.com/metacubex/restls-client-go v0.1.7/go.mod h1:BN/U52vPw7j8VTSh2vleD/MnmVKCov84mS5VcjVHH4g=
++github.com/metacubex/restls-client-go v0.1.9 h1:QmLKwVFuAjB6rL9lQNKj8CuwHqGMJjV36oskeBPEtVs=
++github.com/metacubex/restls-client-go v0.1.9/go.mod h1:BN/U52vPw7j8VTSh2vleD/MnmVKCov84mS5VcjVHH4g=
++github.com/metacubex/sevenzip v1.6.4 h1:OIL+DeOeSAbKNsjqxcYUMiarRmX6Kaxakb0GT7E9Oik=
++github.com/metacubex/sevenzip v1.6.4/go.mod h1:FP3X9bzFKj9wPxifGN9B3w2fIEicMjzKYIGIhnu+1pw=
+ github.com/metacubex/sing v0.5.7 h1:8OC+fhKFSv/l9ehEhJRaZZAOuthfZo68SteBVLe8QqM=
+ github.com/metacubex/sing v0.5.7/go.mod h1:ypf0mjwlZm0sKdQSY+yQvmsbWa0hNPtkeqyRMGgoN+w=
+-github.com/metacubex/sing-mux v0.3.9 h1:/aoBD2+sK2qsXDlNDe3hkR0GZuFDtwIZhOeGUx9W0Yk=
+-github.com/metacubex/sing-mux v0.3.9/go.mod h1:8bT7ZKT3clRrJjYc/x5CRYibC1TX/bK73a3r3+2E+Fc=
+-github.com/metacubex/sing-quic v0.0.0-20260512151354-8475655be853 h1:nZ5WNU6kjj6kBu4+2eMySFkUVGCop64rZnLMm+HPh8w=
+-github.com/metacubex/sing-quic v0.0.0-20260512151354-8475655be853/go.mod h1:6ayFGfzzBE85csgQkM3gf4neFq6s0losHlPRSxY+nuk=
++github.com/metacubex/sing-mux v0.3.10 h1:r5CuZ/KuwFsEcRRwpLvzLncW4fDzNfmSEcBEWcy/+94=
++github.com/metacubex/sing-mux v0.3.10/go.mod h1:8bT7ZKT3clRrJjYc/x5CRYibC1TX/bK73a3r3+2E+Fc=
++github.com/metacubex/sing-quic v0.0.0-20260726014900-38b0e9295f51 h1:FpQj1XfYBIm4LAml+LDjvnfjDs20cSDsFmgjThOqmks=
++github.com/metacubex/sing-quic v0.0.0-20260726014900-38b0e9295f51/go.mod h1:6ayFGfzzBE85csgQkM3gf4neFq6s0losHlPRSxY+nuk=
+ github.com/metacubex/sing-shadowsocks v0.2.12 h1:Wqzo8bYXrK5aWqxu/TjlTnYZzAKtKsaFQBdr6IHFaBE=
+ github.com/metacubex/sing-shadowsocks v0.2.12/go.mod h1:2e5EIaw0rxKrm1YTRmiMnDulwbGxH9hAFlrwQLQMQkU=
+ github.com/metacubex/sing-shadowsocks2 v0.2.7 h1:hSuuc0YpsfiqYqt1o+fP4m34BQz4e6wVj3PPBVhor3A=
+ github.com/metacubex/sing-shadowsocks2 v0.2.7/go.mod h1:vOEbfKC60txi0ca+yUlqEwOGc3Obl6cnSgx9Gf45KjE=
+-github.com/metacubex/sing-shadowtls v0.0.0-20250503063515-5d9f966d17a2 h1:gXU+MYPm7Wme3/OAY2FFzVq9d9GxPHOqu5AQfg/ddhI=
+-github.com/metacubex/sing-shadowtls v0.0.0-20250503063515-5d9f966d17a2/go.mod h1:mbfboaXauKJNIHJYxQRa+NJs4JU9NZfkA+I33dS2+9E=
+-github.com/metacubex/sing-tun v0.4.18 h1:WRzAosG0YkT3aZq5RJWtF+RdCgeJ8EpooS5ZM1lkXo0=
+-github.com/metacubex/sing-tun v0.4.18/go.mod h1:g4I/JNplDBhXLF+aQWgFbhNeJPSXQOWS9HvLeNvkgeA=
++github.com/metacubex/sing-tun v0.4.22 h1:6ARRJ2BIFD1u4r/DTMNcxaNuGyimfXEeUyD4iFJRaZs=
++github.com/metacubex/sing-tun v0.4.22/go.mod h1:9T0SN+FHvzRrn7hgl2kmXy5v8xzzLKW1hITButIPAco=
+ github.com/metacubex/sing-vmess v0.2.5 h1:m9Zt5I27lB9fmLMZfism9sH2LcnAfShZfwSkf6/KJoE=
+ github.com/metacubex/sing-vmess v0.2.5/go.mod h1:AwtlzUgf8COe9tRYAKqWZ+leDH7p5U98a0ZUpYehl8Q=
+-github.com/metacubex/sing-wireguard v0.0.0-20260507084707-690d479ec947 h1:IB03BvRQtvjWScyOK5jSQVJYY8osmZXHL+4VCEFMWcM=
+-github.com/metacubex/sing-wireguard v0.0.0-20260507084707-690d479ec947/go.mod h1:jpAkVLPnCpGSfNyVmj6Cq4YbuZsFepm/Dc+9BAOcR80=
++github.com/metacubex/sing-wireguard v0.0.0-20260810013230-110eac03c3f0 h1:4g/ObGTfHaY2zXcFjKOUO9aAFk+yFjxsZfUPQPG6J8c=
++github.com/metacubex/sing-wireguard v0.0.0-20260810013230-110eac03c3f0/go.mod h1:H27NH3IgI4qk1Wj8kS9pneNMJYEuxFskcQfkfVW9vnw=
+ github.com/metacubex/smux v0.0.0-20260105030934-d0c8756d3141 h1:DK2l6m2Fc85H2BhiAPgbJygiWhesPlfGmF+9Vw6ARdk=
+ github.com/metacubex/smux v0.0.0-20260105030934-d0c8756d3141/go.mod h1:/yI4OiGOSn0SURhZdJF3CbtPg3nwK700bG8TZLMBvAg=
+ github.com/metacubex/ssh v0.1.0 h1:iGfr99qk/eMHzUnQ/0bTxXT8+8SWqLSHBWDHoAhngzw=
+ github.com/metacubex/ssh v0.1.0/go.mod h1:NUtl0d+/f2cG9ECEpMM8iCVOpmggQlC13oLeDUONDlU=
+-github.com/metacubex/tailscale v0.0.0-20260516120020-a21c2c99dcbe h1:ZdAKshacNruZGuKTE8WMTuxyGgpv/LySLoE/EEmgF9c=
+-github.com/metacubex/tailscale v0.0.0-20260516120020-a21c2c99dcbe/go.mod h1:2G1V82OGXgxT7m7046GA80I9SlcvczljCK0C7NQ3c10=
+-github.com/metacubex/tailscale-wireguard-go v0.0.0-20260513233728-8bc7ee255d04 h1:zk+mDDSBl5lv80WWtaFUbpj8XLb7AhjCUbn2pB37N0U=
+-github.com/metacubex/tailscale-wireguard-go v0.0.0-20260513233728-8bc7ee255d04/go.mod h1:pKUKBy7IcQ5r0i66gWENHgxKvBn8tlgAGx0DZMq8h5M=
+-github.com/metacubex/tfo-go v0.0.0-20251130171125-413e892ac443 h1:H6TnfM12tOoTizYE/qBHH3nEuibIelmHI+BVSxVJr8o=
+-github.com/metacubex/tfo-go v0.0.0-20251130171125-413e892ac443/go.mod h1:l9oLnLoEXyGZ5RVLsh7QCC5XsouTUyKk4F2nLm2DHLw=
+-github.com/metacubex/tls v0.1.5 h1:ECcB83dj+zadnhlKcLnUUf1Sq6+vU0f/zoyU0+9oPTc=
+-github.com/metacubex/tls v0.1.5/go.mod h1:0XeVdL0cBw+8i5Hqy3lVeP9IyD/LFTq02ExvHM6rzEM=
+-github.com/metacubex/utls v1.8.4 h1:HmL9nUApDdWSkgUyodfwF6hSjtiwCGGdyhaSpEejKpg=
+-github.com/metacubex/utls v1.8.4/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
++github.com/metacubex/tailscale v0.0.0-20260807072706-a4fb5feabcbb h1:EE4+ehlygfki5qJvkIYs6zJXhv7WFAX+4cDQi/b6cY8=
++github.com/metacubex/tailscale v0.0.0-20260807072706-a4fb5feabcbb/go.mod h1:fMMYScJPYt8Ss3D4VhontA2uV2N9NPZbbXsPP6LgQeo=
++github.com/metacubex/tailscale-wireguard-go v0.0.0-20260725073821-e61ab99cede2 h1:nKyLVJEU4jsLVx+rdqbDUbEKTX/Sdu161AeVoZC9tlY=
++github.com/metacubex/tailscale-wireguard-go v0.0.0-20260725073821-e61ab99cede2/go.mod h1:W00EeoPdd2jbV3+ZUa0m2b7FdKx5B1LFsXvEpy7cToQ=
++github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c h1:+2C1UshSLzaogLY/IDz1XhOLxjhs3rkhVHB4eCN9Zto=
++github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c/go.mod h1:l9oLnLoEXyGZ5RVLsh7QCC5XsouTUyKk4F2nLm2DHLw=
++github.com/metacubex/tls v0.1.8 h1:BHF2payjtxC7wdR3tnq8vl3FAgEQB6/pPjP2tJNTsP4=
++github.com/metacubex/tls v0.1.8/go.mod h1:0XeVdL0cBw+8i5Hqy3lVeP9IyD/LFTq02ExvHM6rzEM=
++github.com/metacubex/utls v1.8.7 h1:Cp+yWkNTFkSihETgGWq34hlVFds5HpYWVOR1xovUVTs=
++github.com/metacubex/utls v1.8.7/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
+ github.com/metacubex/wireguard-go v0.0.0-20250820062549-a6cecdd7f57f h1:FGBPRb1zUabhPhDrlKEjQ9lgIwQ6cHL4x8M9lrERhbk=
+ github.com/metacubex/wireguard-go v0.0.0-20250820062549-a6cecdd7f57f/go.mod h1:oPGcV994OGJedmmxrcK9+ni7jUEMGhR+uVQAdaduIP4=
+ github.com/metacubex/yamux v0.0.0-20250918083631-dd5f17c0be49 h1:lhlqpYHopuTLx9xQt22kSA9HtnyTDmk5XjjQVCGHe2E=
+ github.com/metacubex/yamux v0.0.0-20250918083631-dd5f17c0be49/go.mod h1:MBeEa9IVBphH7vc3LNtW6ZujVXFizotPo3OEiHQ+TNU=
++github.com/metacubex/zerotier-go v0.0.0-20260813124750-13fa6f45da5f h1:OS35JZobxU+AUv+9EjH/ULiKwyGciSK98n1CmxitDFo=
++github.com/metacubex/zerotier-go v0.0.0-20260813124750-13fa6f45da5f/go.mod h1:8LxQupX5KaZ6lIcBMdaJ3u5xx7+OIRyq87uyyFA1Yto=
+ github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
+ github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
+ github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+@@ -195,13 +211,18 @@ github.com/openacid/must v0.1.3/go.mod h1:luPiXCuJlEo3UUFQngVQokV0MPGryeYvtCbQPs
+ github.com/openacid/testkeys v0.1.6/go.mod h1:MfA7cACzBpbiwekivj8StqX0WIRmqlMsci1c37CA3Do=
+ github.com/oschwald/maxminddb-golang v1.12.0 h1:9FnTOD0YOhP7DGxGsq4glzpGy5+w7pq50AS6wALUMYs=
+ github.com/oschwald/maxminddb-golang v1.12.0/go.mod h1:q0Nob5lTCqyQ8WT6FYgS1L7PXKVVbgiymefNwIjPzgY=
+-github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
+ github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
++github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk=
++github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+ github.com/pires/go-proxyproto v0.8.0 h1:5unRmEAPbHXHuLjDg01CxJWf91cw3lKHc/0xzKpXEe0=
+ github.com/pires/go-proxyproto v0.8.0/go.mod h1:iknsfgnH8EkjrMeMyvfKByp9TiBZCKZM0jx2xmKqnVY=
+ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
++github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e h1:dCWirM5F3wMY+cmRda/B1BiPsFtmzXqV9b0hLWtVBMs=
++github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e/go.mod h1:9leZcVcItj6m9/CfHY5Em/iBrCz7js8LcRQGTKEEv2M=
++github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
++github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+ github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
+ github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
+ github.com/sagernet/netlink v0.0.0-20240612041022-b9a21c07ac6a h1:ObwtHN2VpqE0ZNjr6sGeT00J8uU7JF4cNUdb44/Duis=
+@@ -216,10 +237,19 @@ github.com/sina-ghaderi/rabbitio v0.0.0-20220730151941-9ce26f4f872e h1:ur8uMsPIF
+ github.com/sina-ghaderi/rabbitio v0.0.0-20220730151941-9ce26f4f872e/go.mod h1:+e5fBW3bpPyo+3uLo513gIUblc03egGjMM0+5GKbzK8=
+ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
+ github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
++github.com/stangelandcl/ppmd v0.1.1 h1:c25QazhlWUn5nmR1QOzafKhQxBicAr7GGCKER2aJ8H8=
++github.com/stangelandcl/ppmd v0.1.1/go.mod h1:Rrv7M+/2P5jYr/GMLhBl7Ug3uJ1bUiVzr5LbbaV6xgY=
+ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
++github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
++github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
++github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
++github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
++github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
++github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
++github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+ github.com/tailscale/certstore v0.1.1-0.20260409135935-3638fb84b77d h1:JcGKBZAL7ePLwOhUdN8qGQZlP5GueEiIZwY7R62pejE=
+@@ -232,6 +262,8 @@ github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc h1:24heQPtnFR+y
+ github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc/go.mod h1:f93CXfllFsO9ZQVq+Zocb1Gp4G5Fz0b0rXHLOzt/Djc=
+ github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 h1:tHNk7XK9GkmKUR6Gh8gVBKXc2MVSZ4G/NnWLtzw4gNA=
+ github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923/go.mod h1:eLL9Nub3yfAho7qB0MzZizFhTU2QkLeoVsWdHtDW264=
++github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
++github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+@@ -245,6 +277,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+ github.com/xtaci/lossyconn v0.0.0-20190602105132-8df528c0c9ae h1:J0GxkO96kL4WF+AIT3M4mfUVinOCPgf2uUWYFUzN0sM=
+ github.com/xtaci/lossyconn v0.0.0-20190602105132-8df528c0c9ae/go.mod h1:gXtu8J62kEgmN++bm9BVICuT/e8yiLI2KFobd/TRFsE=
++github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
++github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+ github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+ gitlab.com/go-extension/aes-ccm v0.0.0-20230221065045-e58665ef23c7 h1:UNrDfkQqiEYzdMlNsVvBYOAJWZjdktqFE9tQh5BT2+4=
+@@ -271,10 +305,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
+ golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+-golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+-golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+ golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -283,7 +314,6 @@ golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -302,10 +332,11 @@ golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
++gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
++gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+-software.sslmate.com/src/go-pkcs12 v0.2.1 h1:tbT1jjaeFOF230tzOIRJ6U5S1jNqpsSyNjzDd58H3J8=
+-software.sslmate.com/src/go-pkcs12 v0.2.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
++software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
++software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+diff --git a/core/hub.go b/core/hub.go
+index 1d2894a6b6f238357b926d199a4cc49232b7ff70..aad920838f6fefc97bc33f736108cdb78a74fe9a 100644
+--- a/core/hub.go
++++ b/core/hub.go
+@@ -347,36 +347,22 @@ func handleGetExternalProvider(externalProviderName string) string {
+ 	return string(data)
+ }
+ 
+-func handleUpdateGeoData(geoType string, geoName string, fn func(value string)) {
++func handleUpdateGeoData(geoType string) {
+ 	go func() {
+-		path := constant.Path.Resolve(geoName)
+ 		switch geoType {
+ 		case "MMDB":
+-			err := updater.UpdateMMDBWithPath(path)
+-			if err != nil {
+-				fn(err.Error())
+-				return
+-			}
++			updater.UpdateMMDB()
++			return
+ 		case "ASN":
+-			err := updater.UpdateASNWithPath(path)
+-			if err != nil {
+-				fn(err.Error())
+-				return
+-			}
++			updater.UpdateASN()
++			return
+ 		case "GEOIP":
+-			err := updater.UpdateGeoIpWithPath(path)
+-			if err != nil {
+-				fn(err.Error())
+-				return
+-			}
++			updater.UpdateGeoIp()
++			return
+ 		case "GEOSITE":
+-			err := updater.UpdateGeoSiteWithPath(path)
+-			if err != nil {
+-				fn(err.Error())
+-				return
+-			}
++			updater.UpdateGeoSite()
++			return
+ 		}
+-		fn("")
+ 	}()
+ }
+ 
+@@ -568,4 +554,18 @@ func init() {
+ 			Data: providerName,
+ 		})
+ 	}
++	updater.GeoUpdateHook = func(geoType string, updating bool, skipped bool, updateErr error) {
++		status := GeoUpdateStatus{
++			Type:     geoType,
++			Updating: updating,
++			Skipped:  skipped,
++		}
++		if updateErr != nil {
++			status.Error = updateErr.Error()
++		}
++		sendMessage(Message{
++			Type: GeoUpdateMessage,
++			Data: status,
++		})
++	}
+ }

--- a/scripts/patches/mihomo-v1.19.30-flclash.patch
+++ b/scripts/patches/mihomo-v1.19.30-flclash.patch
@@ -1,0 +1,1737 @@
+diff --git a/adapter/adapter.go b/adapter/adapter.go
+index 6f20c08abb43eb0ddef4f2ccf989ab0254e7f5ed..22054f0709ef2193aa26a5ecb017142717237c1b 100644
+--- a/adapter/adapter.go
++++ b/adapter/adapter.go
+@@ -167,6 +167,10 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
+ 	var satisfied bool
+ 
+ 	defer func() {
++		if UrlTestHook != nil {
++			UrlTestHook(url, p.Name(), t)
++		}
++
+ 		alive := err == nil
+ 		record := C.DelayHistory{Time: time.Now()}
+ 		if alive {
+diff --git a/adapter/outbound/wireguard.go b/adapter/outbound/wireguard.go
+index b856c5c846d55d4976081812365daa42006d1753..e4c784daf30473b7902a9ad4f29b4a412e1f682b 100644
+--- a/adapter/outbound/wireguard.go
++++ b/adapter/outbound/wireguard.go
+@@ -2,10 +2,13 @@ package outbound
+ 
+ import (
+ 	"context"
++	"crypto/rand"
+ 	"encoding/base64"
++	"encoding/binary"
+ 	"encoding/hex"
+ 	"errors"
+ 	"fmt"
++	"hash/fnv"
+ 	"net"
+ 	"net/netip"
+ 	"os"
+@@ -26,14 +29,17 @@ import (
+ 
+ 	amneziav3 "github.com/metacubex/amneziawg-go/device"
+ 	amnezia "github.com/metacubex/amneziawg-go/device_v1"
++	amneziaawg "github.com/metacubex/amneziawg-go/device_v1/awg"
+ 	"github.com/metacubex/mipstack"
+ 	wireguard "github.com/metacubex/sing-wireguard"
++	wgconn "github.com/metacubex/wireguard-go/conn"
+ 	"github.com/metacubex/wireguard-go/device"
+ 	"github.com/metacubex/wireguard-go/tun"
+ 
+ 	"github.com/metacubex/sing/common/debug"
+ 	E "github.com/metacubex/sing/common/exceptions"
+ 	M "github.com/metacubex/sing/common/metadata"
++	N "github.com/metacubex/sing/common/network"
+ )
+ 
+ const (
+@@ -47,6 +53,263 @@ type wireguardGoDevice interface {
+ 	IpcSet(uapiConf string) error
+ }
+ 
++const (
++	wireGuardHandshakeInitiationSize = 148
++	maxWireGuardDPIFakeCount         = 20
++	maxWireGuardDPIFakeSize          = 1280
++	maxWireGuardDPIFakeTTL           = 255
++	wireGuardDefaultDPIFakeTTL       = 3
++)
++
++type wireGuardDPIStrategy uint32
++
++const (
++	wireGuardDPIStrategyBurst wireGuardDPIStrategy = iota
++	wireGuardDPIStrategyPairedDuplicates
++	wireGuardDPIStrategyInterleavedDuplicates
++	wireGuardDPIStrategyTTL
++	wireGuardDPIStrategyCount
++)
++
++type wireGuardDPIBind struct {
++	wgconn.Bind
++	option    WireGuardDPIOption
++	pattern   wireGuardInitiationPattern
++	control   *wireGuardDPIWriteControl
++	identity  string
++	rotations map[string]uint32
++	mutex     sync.Mutex
++}
++
++type WireGuardDPIOption struct {
++	FakeCount   int `proxy:"fake-count,omitempty"`
++	FakeMinSize int `proxy:"fake-min-size,omitempty"`
++	FakeMaxSize int `proxy:"fake-max-size,omitempty"`
++	FakeTTL     int `proxy:"fake-ttl,omitempty"`
++}
++
++type wireGuardInitiationPattern struct {
++	size       int
++	typeOffset int
++	typeMin    uint32
++	typeMax    uint32
++}
++
++type wireGuardDPIWriteControl struct {
++	ttl int
++}
++
++type wireGuardDPIDialer struct {
++	N.Dialer
++	control *wireGuardDPIWriteControl
++}
++
++type wireGuardDPIUDPConn struct {
++	*net.UDPConn
++	control *wireGuardDPIWriteControl
++}
++
++var (
++	_ wgconn.Bind    = (*wireGuardDPIBind)(nil)
++	_ N.Dialer       = (*wireGuardDPIDialer)(nil)
++	_ net.Conn       = (*wireGuardDPIUDPConn)(nil)
++	_ net.PacketConn = (*wireGuardDPIUDPConn)(nil)
++)
++
++func (o WireGuardDPIOption) enabled() bool {
++	return o.FakeCount != 0 || o.FakeMinSize != 0 || o.FakeMaxSize != 0 || o.FakeTTL != 0
++}
++
++func (o WireGuardDPIOption) validate() error {
++	if o.FakeCount < 1 || o.FakeCount > maxWireGuardDPIFakeCount {
++		return E.New("wireguard dpi fake-count must be between 1 and ", maxWireGuardDPIFakeCount)
++	}
++	if o.FakeMinSize < 1 || o.FakeMaxSize > maxWireGuardDPIFakeSize || o.FakeMinSize > o.FakeMaxSize {
++		return E.New("wireguard dpi sizes must satisfy 1 <= fake-min-size <= fake-max-size <= ", maxWireGuardDPIFakeSize)
++	}
++	if o.FakeTTL < 0 || o.FakeTTL > maxWireGuardDPIFakeTTL {
++		return E.New("wireguard dpi fake-ttl must be between 0 and ", maxWireGuardDPIFakeTTL)
++	}
++	return nil
++}
++
++func (p wireGuardInitiationPattern) matches(packet []byte) bool {
++	if len(packet) != p.size || p.typeOffset < 0 || p.typeOffset+4 > len(packet) {
++		return false
++	}
++	messageType := binary.LittleEndian.Uint32(packet[p.typeOffset : p.typeOffset+4])
++	return messageType >= p.typeMin && messageType <= p.typeMax
++}
++
++func newWireGuardInitiationPattern(option *AmneziaWGOption) (wireGuardInitiationPattern, error) {
++	pattern := wireGuardInitiationPattern{
++		size:    wireGuardHandshakeInitiationSize,
++		typeMin: 1,
++		typeMax: 1,
++	}
++	if option == nil || !option.hasHandshakeChanges() {
++		return pattern, nil
++	}
++	if option.S1 < 0 {
++		return pattern, E.New("wireguard dpi cannot match a negative amnezia s1")
++	}
++	pattern.size += option.S1
++	pattern.typeOffset = option.S1
++	if option.H1 == "" {
++		return pattern, nil
++	}
++	header, err := amneziaawg.ParseMagicHeader("h1", option.H1)
++	if err != nil {
++		return pattern, E.Cause(err, "parse amnezia h1 for wireguard dpi")
++	}
++	if header.Min > 4 {
++		pattern.typeMin = header.Min
++		pattern.typeMax = header.Max
++	}
++	return pattern, nil
++}
++
++func (b *wireGuardDPIBind) Send(bufs [][]byte, endpoint wgconn.Endpoint) error {
++	b.mutex.Lock()
++	defer b.mutex.Unlock()
++	if len(bufs) != 1 || !b.pattern.matches(bufs[0]) {
++		return b.send(bufs, endpoint, 0)
++	}
++
++	strategy := b.nextStrategy(endpoint)
++	for _, fake := range b.fakePlan(strategy) {
++		ttl := 0
++		if strategy == wireGuardDPIStrategyTTL {
++			ttl = b.option.FakeTTL
++		}
++		if err := b.send([][]byte{fake}, endpoint, ttl); err != nil {
++			break
++		}
++	}
++	// Every strategy is fail-open and leaves the authenticated packet untouched.
++	return b.send(bufs, endpoint, 0)
++}
++
++func (b *wireGuardDPIBind) nextStrategy(endpoint wgconn.Endpoint) wireGuardDPIStrategy {
++	endpointKey := ""
++	if endpoint != nil {
++		endpointKey = endpoint.DstToString()
++	}
++	attempt := b.rotations[endpointKey]
++	b.rotations[endpointKey] = attempt + 1
++	hash := fnv.New32a()
++	_, _ = hash.Write([]byte(b.identity + "|" + endpointKey))
++	return wireGuardDPIStrategy((hash.Sum32() + attempt) % uint32(wireGuardDPIStrategyCount))
++}
++
++func (b *wireGuardDPIBind) fakePlan(strategy wireGuardDPIStrategy) [][]byte {
++	if strategy != wireGuardDPIStrategyPairedDuplicates && strategy != wireGuardDPIStrategyInterleavedDuplicates {
++		fakes := make([][]byte, 0, b.option.FakeCount)
++		for len(fakes) < b.option.FakeCount {
++			if fake := b.randomFakePacket(); fake != nil {
++				fakes = append(fakes, fake)
++			} else {
++				break
++			}
++		}
++		return fakes
++	}
++
++	unique := make([][]byte, 0, (b.option.FakeCount+1)/2)
++	for len(unique) < cap(unique) {
++		if fake := b.randomFakePacket(); fake != nil {
++			unique = append(unique, fake)
++		} else {
++			break
++		}
++	}
++	plan := make([][]byte, 0, b.option.FakeCount)
++	if strategy == wireGuardDPIStrategyPairedDuplicates {
++		for _, fake := range unique {
++			plan = append(plan, fake)
++			if len(plan) < b.option.FakeCount {
++				plan = append(plan, fake)
++			}
++		}
++		return plan
++	}
++	plan = append(plan, unique...)
++	for _, fake := range unique {
++		if len(plan) == b.option.FakeCount {
++			break
++		}
++		plan = append(plan, fake)
++	}
++	return plan
++}
++
++func (b *wireGuardDPIBind) randomFakePacket() []byte {
++	size := b.option.FakeMinSize
++	if span := b.option.FakeMaxSize - b.option.FakeMinSize + 1; span > 1 {
++		var sample [2]byte
++		if _, err := rand.Read(sample[:]); err == nil {
++			size += int(binary.LittleEndian.Uint16(sample[:])) % span
++		}
++	}
++	fake := make([]byte, size)
++	if _, err := rand.Read(fake); err != nil {
++		return nil
++	}
++	if b.pattern.typeOffset+4 <= len(fake) {
++		binary.LittleEndian.PutUint32(fake[b.pattern.typeOffset:b.pattern.typeOffset+4], 0)
++	} else {
++		fake[0] = 0
++	}
++	return fake
++}
++
++func (b *wireGuardDPIBind) send(bufs [][]byte, endpoint wgconn.Endpoint, ttl int) error {
++	b.control.ttl = ttl
++	defer func() { b.control.ttl = 0 }()
++	return b.Bind.Send(bufs, endpoint)
++}
++
++func (d *wireGuardDPIDialer) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
++	connection, err := d.Dialer.DialContext(ctx, network, destination)
++	if err != nil {
++		return nil, err
++	}
++	if udpConn, ok := connection.(*net.UDPConn); ok {
++		return &wireGuardDPIUDPConn{UDPConn: udpConn, control: d.control}, nil
++	}
++	return connection, nil
++}
++
++func (d *wireGuardDPIDialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
++	packetConn, err := d.Dialer.ListenPacket(ctx, destination)
++	if err != nil {
++		return nil, err
++	}
++	if udpConn, ok := packetConn.(*net.UDPConn); ok {
++		return &wireGuardDPIUDPConn{UDPConn: udpConn, control: d.control}, nil
++	}
++	return packetConn, nil
++}
++
++func (c *wireGuardDPIUDPConn) Write(payload []byte) (int, error) {
++	if c.control.ttl > 0 {
++		if n, err, supported := writeWireGuardUDPWithTTL(c.UDPConn, payload, nil, c.control.ttl); supported && (err == nil || n > 0) {
++			return n, err
++		}
++	}
++	return c.UDPConn.Write(payload)
++}
++
++func (c *wireGuardDPIUDPConn) WriteTo(payload []byte, destination net.Addr) (int, error) {
++	udpDestination, isUDP := destination.(*net.UDPAddr)
++	if c.control.ttl > 0 && isUDP {
++		if n, err, supported := writeWireGuardUDPWithTTL(c.UDPConn, payload, udpDestination, c.control.ttl); supported && (err == nil || n > 0) {
++			return n, err
++		}
++	}
++	return c.UDPConn.WriteTo(payload, destination)
++}
++
+ type WireGuard struct {
+ 	*Base
+ 	bind      *wireguard.ClientBind
+@@ -80,7 +343,8 @@ type WireGuardOption struct {
+ 
+ 	IPStack IPStackOption `proxy:"ip-stack,omitempty"`
+ 
+-	AmneziaWGOption *AmneziaWGOption `proxy:"amnezia-wg-option,omitempty"`
++	AmneziaWGOption *AmneziaWGOption    `proxy:"amnezia-wg-option,omitempty"`
++	DPIOption       *WireGuardDPIOption `proxy:"wireguard-dpi-option,omitempty"`
+ 
+ 	Peers []WireGuardPeerOption `proxy:"peers,omitempty"`
+ 
+@@ -288,6 +552,16 @@ func newWireguardDevice(stack ipStack) (wireguardDevice, error) {
+ 	}, nil
+ }
+ 
++func (o *AmneziaWGOption) hasHandshakeChanges() bool {
++	return o.Version == 3 || o.S1 != 0 || o.S2 != 0 || o.S3 != 0 || o.S4 != 0 ||
++		o.H1 != "" || o.H2 != "" || o.H3 != "" || o.H4 != "" ||
++		o.I1 != "" || o.I2 != "" || o.I3 != "" || o.I4 != "" || o.I5 != "" ||
++		o.J1 != "" || o.J2 != "" || o.J3 != "" || o.Itime != 0 ||
++		o.HeaderProtectionKey != "" || o.ContentPaddingAddition != "" || o.RekeyAfterTime != "" ||
++		o.RekeyTimeout != "" || o.RejectAfterTime != "" || o.KeepaliveTimeout != "" ||
++		o.MaxHandshakeAttempts != "" || o.RandomTrailers || o.DisableCookies
++}
++
+ type wgSingErrorHandler struct {
+ 	name string
+ }
+@@ -345,6 +619,35 @@ func (option WireGuardOption) Prefixes() ([]netip.Prefix, error) {
+ }
+ 
+ func NewWireGuard(option WireGuardOption) (*WireGuard, error) {
++	dpiOption := option.DPIOption
++	// Legacy junk-only options use the standard device so WARP handshakes and reserved bytes stay intact.
++	if awg := option.AmneziaWGOption; awg != nil && !awg.hasHandshakeChanges() {
++		if dpiOption == nil && (awg.JC != 0 || awg.JMin != 0 || awg.JMax != 0) {
++			dpiOption = &WireGuardDPIOption{
++				FakeCount:   awg.JC,
++				FakeMinSize: awg.JMin,
++				FakeMaxSize: awg.JMax,
++				FakeTTL:     wireGuardDefaultDPIFakeTTL,
++			}
++		}
++		option.AmneziaWGOption = nil
++	}
++	if dpiOption != nil {
++		if !dpiOption.enabled() {
++			dpiOption = nil
++		} else if err := dpiOption.validate(); err != nil {
++			return nil, err
++		}
++	}
++	option.DPIOption = dpiOption
++	var initiationPattern wireGuardInitiationPattern
++	var err error
++	if dpiOption != nil {
++		initiationPattern, err = newWireGuardInitiationPattern(option.AmneziaWGOption)
++		if err != nil {
++			return nil, err
++		}
++	}
+ 	outbound := &WireGuard{
+ 		Base: NewBase(BaseOption{
+ 			Name:         option.Name,
+@@ -359,6 +662,14 @@ func NewWireGuard(option WireGuardOption) (*WireGuard, error) {
+ 	}
+ 	outbound.dialer = option.NewDialer(outbound.DialOptions())
+ 	singDialer := proxydialer.NewSingDialer(proxydialer.NewSlowDownDialer(outbound.dialer, slowdown.New()))
++	var clientDialer N.Dialer = singDialer
++	var dpiControl *wireGuardDPIWriteControl
++	if dpiOption != nil {
++		dpiControl = &wireGuardDPIWriteControl{}
++		if option.DialerProxy == "" && option.DialerForAPI == nil {
++			clientDialer = &wireGuardDPIDialer{Dialer: clientDialer, control: dpiControl}
++		}
++	}
+ 
+ 	var reserved [3]uint8
+ 	if len(option.Reserved) > 0 {
+@@ -376,9 +687,8 @@ func NewWireGuard(option WireGuardOption) (*WireGuard, error) {
+ 			outbound.connectAddr = option.Addr()
+ 		}
+ 	}
+-	outbound.bind = wireguard.NewClientBind(context.Background(), wgSingErrorHandler{outbound.Name()}, singDialer, isConnect, outbound.connectAddr.AddrPort(), reserved)
++	outbound.bind = wireguard.NewClientBind(context.Background(), wgSingErrorHandler{outbound.Name()}, clientDialer, isConnect, outbound.connectAddr.AddrPort(), reserved)
+ 
+-	var err error
+ 	outbound.localPrefixes, err = option.Prefixes()
+ 	if err != nil {
+ 		return nil, err
+@@ -474,15 +784,26 @@ func NewWireGuard(option WireGuardOption) (*WireGuard, error) {
+ 			log.SingLogger.Error(fmt.Sprintf("[WG](%s) %s", option.Name, fmt.Sprintf(format, args...)))
+ 		},
+ 	}
++	deviceBind := wgconn.Bind(outbound.bind)
++	if dpiOption != nil {
++		deviceBind = &wireGuardDPIBind{
++			Bind:      deviceBind,
++			option:    *dpiOption,
++			pattern:   initiationPattern,
++			control:   dpiControl,
++			identity:  option.Name,
++			rotations: make(map[string]uint32),
++		}
++	}
+ 	if option.AmneziaWGOption != nil {
+ 		outbound.bind.SetParseReserved(false) // AmneziaWG don't need parse reserved
+ 		if option.AmneziaWGOption.Version == 3 {
+-			outbound.device = amneziav3.NewDevice(outbound.tunDevice, outbound.bind, logger, option.Workers)
++			outbound.device = amneziav3.NewDevice(outbound.tunDevice, deviceBind, logger, option.Workers)
+ 		} else {
+-			outbound.device = amnezia.NewDevice(outbound.tunDevice, outbound.bind, logger, option.Workers)
++			outbound.device = amnezia.NewDevice(outbound.tunDevice, deviceBind, logger, option.Workers)
+ 		}
+ 	} else {
+-		outbound.device = device.NewDevice(outbound.tunDevice, outbound.bind, logger, option.Workers)
++		outbound.device = device.NewDevice(outbound.tunDevice, deviceBind, logger, option.Workers)
+ 	}
+ 
+ 	var has6 bool
+diff --git a/adapter/outbound/wireguard_dpi_ttl_other.go b/adapter/outbound/wireguard_dpi_ttl_other.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..c322d1b3fe104ca08c740d067b8fd473be1b3a4d
+--- /dev/null
++++ b/adapter/outbound/wireguard_dpi_ttl_other.go
+@@ -0,0 +1,14 @@
++//go:build !linux && !android
++
++package outbound
++
++import "net"
++
++func writeWireGuardUDPWithTTL(
++	_ *net.UDPConn,
++	_ []byte,
++	_ *net.UDPAddr,
++	_ int,
++) (int, error, bool) {
++	return 0, nil, false
++}
+diff --git a/adapter/outbound/wireguard_dpi_ttl_unix.go b/adapter/outbound/wireguard_dpi_ttl_unix.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..d552b878cbd306f46f7d1872bc915972d03b5e1f
+--- /dev/null
++++ b/adapter/outbound/wireguard_dpi_ttl_unix.go
+@@ -0,0 +1,38 @@
++//go:build linux || android
++
++package outbound
++
++import (
++	"net"
++	"syscall"
++	"unsafe"
++)
++
++func writeWireGuardUDPWithTTL(
++	connection *net.UDPConn,
++	payload []byte,
++	destination *net.UDPAddr,
++	ttl int,
++) (int, error, bool) {
++	remote := destination
++	if remote == nil {
++		remote, _ = connection.RemoteAddr().(*net.UDPAddr)
++	}
++	if remote == nil || ttl < 1 || ttl > 255 {
++		return 0, nil, false
++	}
++
++	control := make([]byte, syscall.CmsgSpace(4))
++	header := (*syscall.Cmsghdr)(unsafe.Pointer(&control[0]))
++	if remote.IP.To4() == nil {
++		header.Level = syscall.IPPROTO_IPV6
++		header.Type = syscall.IPV6_HOPLIMIT
++	} else {
++		header.Level = syscall.IPPROTO_IP
++		header.Type = syscall.IP_TTL
++	}
++	header.SetLen(syscall.CmsgLen(4))
++	*(*int32)(unsafe.Pointer(&control[syscall.CmsgLen(0)])) = int32(ttl)
++	n, _, err := connection.WriteMsgUDP(payload, control, destination)
++	return n, err, true
++}
+diff --git a/adapter/outbound/wireguard_udp_desync_test.go b/adapter/outbound/wireguard_udp_desync_test.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..7de1c16f5244b9eb285abea7c9dfeeeca36c53b3
+--- /dev/null
++++ b/adapter/outbound/wireguard_udp_desync_test.go
+@@ -0,0 +1,181 @@
++package outbound
++
++import (
++	"bytes"
++	"encoding/binary"
++	"errors"
++	"testing"
++
++	wgconn "github.com/metacubex/wireguard-go/conn"
++)
++
++type recordedWireGuardSend struct {
++	bufs []byte
++	ttl  int
++}
++
++type recordingWireGuardBind struct {
++	wgconn.Bind
++	control   *wireGuardDPIWriteControl
++	sends     []recordedWireGuardSend
++	failFirst bool
++}
++
++func (b *recordingWireGuardBind) Send(bufs [][]byte, _ wgconn.Endpoint) error {
++	for _, buf := range bufs {
++		b.sends = append(b.sends, recordedWireGuardSend{
++			bufs: bytes.Clone(buf),
++			ttl:  b.control.ttl,
++		})
++	}
++	if b.failFirst && len(b.sends) == 1 {
++		return errors.New("fake send failed")
++	}
++	return nil
++}
++
++func TestWireGuardDPIStrategyEngine(t *testing.T) {
++	if (&AmneziaWGOption{JC: 2, JMin: 64, JMax: 64}).hasHandshakeChanges() {
++		t.Fatal("legacy junk-only options must keep standard WireGuard")
++	}
++	if !(&AmneziaWGOption{S1: 15}).hasHandshakeChanges() {
++		t.Fatal("Amnezia handshake fields must keep the AmneziaWG device")
++	}
++	awgPattern, err := newWireGuardInitiationPattern(&AmneziaWGOption{S1: 10, H1: "100-200"})
++	if err != nil {
++		t.Fatal(err)
++	}
++	awgHandshake := make([]byte, wireGuardHandshakeInitiationSize+10)
++	binary.LittleEndian.PutUint32(awgHandshake[10:], 150)
++	if !awgPattern.matches(awgHandshake) {
++		t.Fatal("Amnezia initiation range was not recognized")
++	}
++
++	option := WireGuardDPIOption{FakeCount: 4, FakeMinSize: 64, FakeMaxSize: 64, FakeTTL: 3}
++	if err := option.validate(); err != nil {
++		t.Fatal(err)
++	}
++	awgControl := &wireGuardDPIWriteControl{}
++	awgRecorder := &recordingWireGuardBind{control: awgControl}
++	awgBind := &wireGuardDPIBind{
++		Bind:      awgRecorder,
++		option:    option,
++		pattern:   awgPattern,
++		control:   awgControl,
++		identity:  "profile-awg",
++		rotations: make(map[string]uint32),
++	}
++	if err := awgBind.Send([][]byte{awgHandshake}, nil); err != nil {
++		t.Fatal(err)
++	}
++	if len(awgRecorder.sends) != option.FakeCount+1 {
++		t.Fatalf("Amnezia initiation sent %d packets, want %d", len(awgRecorder.sends), option.FakeCount+1)
++	}
++	var awgRealCount int
++	for _, send := range awgRecorder.sends {
++		if bytes.Equal(send.bufs, awgHandshake) {
++			awgRealCount++
++		}
++	}
++	awgReal := awgRecorder.sends[len(awgRecorder.sends)-1]
++	if awgRealCount != 1 || awgReal.ttl != 0 || !bytes.Equal(awgReal.bufs, awgHandshake) {
++		t.Fatal("Amnezia initiation must be the final packet and sent exactly once without fake TTL")
++	}
++
++	standardHandshake := make([]byte, wireGuardHandshakeInitiationSize)
++	binary.LittleEndian.PutUint32(standardHandshake, 1)
++	standardStart := len(awgRecorder.sends)
++	if err := awgBind.Send([][]byte{standardHandshake}, nil); err != nil {
++		t.Fatal(err)
++	}
++	if len(awgRecorder.sends) != standardStart+1 || !bytes.Equal(awgRecorder.sends[standardStart].bufs, standardHandshake) {
++		t.Fatal("standard initiation must not be classified as an Amnezia initiation")
++	}
++
++	control := &wireGuardDPIWriteControl{}
++	recorder := &recordingWireGuardBind{control: control}
++	bind := &wireGuardDPIBind{
++		Bind:      recorder,
++		option:    option,
++		pattern:   wireGuardInitiationPattern{size: wireGuardHandshakeInitiationSize, typeMin: 1, typeMax: 1},
++		control:   control,
++		identity:  "profile-a",
++		rotations: make(map[string]uint32),
++	}
++
++	pairedPlan := bind.fakePlan(wireGuardDPIStrategyPairedDuplicates)
++	if !bytes.Equal(pairedPlan[0], pairedPlan[1]) || !bytes.Equal(pairedPlan[2], pairedPlan[3]) {
++		t.Fatal("paired strategy did not duplicate adjacent decoys")
++	}
++	interleavedPlan := bind.fakePlan(wireGuardDPIStrategyInterleavedDuplicates)
++	if !bytes.Equal(interleavedPlan[0], interleavedPlan[2]) || !bytes.Equal(interleavedPlan[1], interleavedPlan[3]) {
++		t.Fatal("interleaved strategy did not preserve controlled ordering")
++	}
++	randomPlan := bind.fakePlan(wireGuardDPIStrategyBurst)
++	if bytes.Equal(randomPlan[0], randomPlan[1]) {
++		t.Fatal("independent decoys were not randomized")
++	}
++
++	handshake := make([]byte, wireGuardHandshakeInitiationSize)
++	binary.LittleEndian.PutUint32(handshake, 1)
++	handshake[10] = 42
++	seenStrategies := make(map[wireGuardDPIStrategy]bool)
++	for attempt := 0; attempt < int(wireGuardDPIStrategyCount); attempt++ {
++		strategy := bind.nextStrategy(nil)
++		bind.rotations[""]--
++		start := len(recorder.sends)
++		if err := bind.Send([][]byte{handshake}, nil); err != nil {
++			t.Fatal(err)
++		}
++		sends := recorder.sends[start:]
++		if len(sends) != option.FakeCount+1 {
++			t.Fatalf("strategy %d sent %d packets, want %d", strategy, len(sends), option.FakeCount+1)
++		}
++		for _, fake := range sends[:option.FakeCount] {
++			if len(fake.bufs) != 64 || fake.bufs[0] != 0 {
++				t.Fatalf("strategy %d emitted a valid or incorrectly sized decoy", strategy)
++			}
++			if strategy == wireGuardDPIStrategyTTL && fake.ttl != option.FakeTTL {
++				t.Fatalf("TTL strategy used ttl=%d, want %d", fake.ttl, option.FakeTTL)
++			}
++			if strategy != wireGuardDPIStrategyTTL && fake.ttl != 0 {
++				t.Fatalf("strategy %d unexpectedly used ttl=%d", strategy, fake.ttl)
++			}
++		}
++		real := sends[len(sends)-1]
++		if real.ttl != 0 || !bytes.Equal(real.bufs, handshake) {
++			t.Fatal("real handshake was modified or inherited fake TTL")
++		}
++		seenStrategies[strategy] = true
++	}
++	if len(seenStrategies) != int(wireGuardDPIStrategyCount) {
++		t.Fatalf("rotation covered %d strategies, want %d", len(seenStrategies), wireGuardDPIStrategyCount)
++	}
++
++	transport := make([]byte, 32)
++	binary.LittleEndian.PutUint32(transport, 4)
++	start := len(recorder.sends)
++	if err := bind.Send([][]byte{transport}, nil); err != nil {
++		t.Fatal(err)
++	}
++	if len(recorder.sends) != start+1 || !bytes.Equal(recorder.sends[start].bufs, transport) {
++		t.Fatal("non-initiation packets must pass through unchanged")
++	}
++
++	failControl := &wireGuardDPIWriteControl{}
++	failingRecorder := &recordingWireGuardBind{control: failControl, failFirst: true}
++	failOpenBind := &wireGuardDPIBind{
++		Bind:      failingRecorder,
++		option:    option,
++		pattern:   bind.pattern,
++		control:   failControl,
++		identity:  "profile-b",
++		rotations: make(map[string]uint32),
++	}
++	if err := failOpenBind.Send([][]byte{handshake}, nil); err != nil {
++		t.Fatal(err)
++	}
++	if len(failingRecorder.sends) != 2 || !bytes.Equal(failingRecorder.sends[1].bufs, handshake) {
++		t.Fatal("a decoy failure must still send the real handshake")
++	}
++}
+diff --git a/adapter/patch.go b/adapter/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..4391c56be65041f228fe723798cb802afbcb6b38
+--- /dev/null
++++ b/adapter/patch.go
+@@ -0,0 +1,5 @@
++package adapter
++
++type UrlTestCheck func(url string, name string, delay uint16)
++
++var UrlTestHook UrlTestCheck
+diff --git a/adapter/provider/patch.go b/adapter/provider/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..1f3306a62b3626f372a4b821994a2cd24c137630
+--- /dev/null
++++ b/adapter/provider/patch.go
+@@ -0,0 +1,5 @@
++package provider
++
++func (pp *proxySetProvider) GetSubscriptionInfo() *SubscriptionInfo {
++	return pp.subscriptionInfo
++}
+diff --git a/component/loopback/detector.go b/component/loopback/detector.go
+index 59d16ca8a49bfd2620207ec1980a011b89ab42fe..02f71373b4ea5fa895841f9119813be571fc07a3 100644
+--- a/component/loopback/detector.go
++++ b/component/loopback/detector.go
+@@ -17,7 +17,7 @@ import (
+ var disableLoopBackDetector, _ = strconv.ParseBool(os.Getenv("DISABLE_LOOPBACK_DETECTOR"))
+ 
+ func init() {
+-	if features.CMFA {
++	if features.Android {
+ 		disableLoopBackDetector = true
+ 	}
+ }
+diff --git a/component/process/process.go b/component/process/process.go
+index 464f5a79bc445a904ee5711fc159f76622607e53..8b758b91c8e397de65e79c74aaf834b9cb3a25cb 100644
+--- a/component/process/process.go
++++ b/component/process/process.go
+@@ -22,12 +22,10 @@ func FindProcessName(network string, srcIP netip.Addr, srcPort int) (uint32, str
+ 	return findProcessName(network, srcIP, srcPort)
+ }
+ 
+-// PackageNameResolver
+-// never change type traits because it's used in CMFA
+ type PackageNameResolver func(metadata *C.Metadata) (string, error)
+ 
+ // DefaultPackageNameResolver
+-// never change type traits because it's used in CMFA
++// never change type traits because it's used in CFMA
+ var DefaultPackageNameResolver PackageNameResolver
+ 
+ func FindPackageName(metadata *C.Metadata) (string, error) {
+diff --git a/component/resource/fetcher.go b/component/resource/fetcher.go
+index 464af2e702a2fbd174d96f4316cc7f9e598a2236..6d671c815861e83d8e404522acf6a7953d019cd7 100644
+--- a/component/resource/fetcher.go
++++ b/component/resource/fetcher.go
+@@ -236,7 +236,7 @@ func (f *Fetcher[V]) updateCallback(path string) {
+ func (f *Fetcher[V]) updateWithLog() {
+ 	_, same, err := f.Update()
+ 	if err != nil {
+-		log.Errorln("[Provider] %s pull error: %s", f.Name(), err.Error())
++		log.Warnln("[Provider] %s pull error: %s", f.Name(), err.Error())
+ 		return
+ 	}
+ 
+diff --git a/component/updater/patch.go b/component/updater/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..f969393876dc103386371643ba1c432106db6ab0
+--- /dev/null
++++ b/component/updater/patch.go
+@@ -0,0 +1,67 @@
++package updater
++
++import (
++	"context"
++	"time"
++
++	"github.com/metacubex/mihomo/log"
++)
++
++var (
++	GeoUpdateHook func(geoType string, updating bool, skipped bool, updateErr error)
++)
++
++func sendGeoUpdateStatus(geoType string, updating bool, skipped bool, updateErr error) {
++	if GeoUpdateHook != nil {
++		GeoUpdateHook(geoType, updating, skipped, updateErr)
++	}
++}
++
++var geoUpdateCancel context.CancelFunc
++
++func RegisterGeoUpdaterWithCancel() {
++	if geoUpdateCancel != nil {
++		geoUpdateCancel()
++	}
++
++	if updateInterval <= 0 {
++		log.Errorln("[GEO] Invalid update interval: %d", updateInterval)
++		return
++	}
++
++	ctx, cancel := context.WithCancel(context.Background())
++	geoUpdateCancel = cancel
++
++	go func() {
++		ticker := time.NewTicker(time.Duration(updateInterval) * time.Hour)
++		defer ticker.Stop()
++
++		lastUpdate, err := getUpdateTime()
++		if err != nil {
++			log.Errorln("[GEO] Get GEO database update time error: %s", err.Error())
++			return
++		}
++
++		log.Infoln("[GEO] last update time %s", lastUpdate)
++		if lastUpdate.Add(time.Duration(updateInterval) * time.Hour).Before(time.Now()) {
++			log.Infoln("[GEO] Database has not been updated for %v, update now", time.Duration(updateInterval)*time.Hour)
++			if err := UpdateGeoDatabases(); err != nil {
++				log.Errorln("[GEO] Failed to update GEO database: %s", err.Error())
++				return
++			}
++		}
++
++		for {
++			select {
++			case <-ctx.Done():
++				log.Infoln("[GEO] Geo updater stopped")
++				return
++			case <-ticker.C:
++				log.Infoln("[GEO] updating database every %d hours", updateInterval)
++				if err := UpdateGeoDatabases(); err != nil {
++					log.Errorln("[GEO] Failed to update GEO database: %s", err.Error())
++				}
++			}
++		}
++	}()
++}
+diff --git a/component/updater/update_geo.go b/component/updater/update_geo.go
+index 63e6d1501266ee90be4698c9c2d096320186af61..19c5a211f6b8bacc27f2e36939c47d58fc929a36 100644
+--- a/component/updater/update_geo.go
++++ b/component/updater/update_geo.go
+@@ -45,6 +45,10 @@ func SetGeoUpdateInterval(newGeoUpdateInterval int) {
+ }
+ 
+ func UpdateMMDB() (err error) {
++	sendGeoUpdateStatus("MMDB", true, false, nil)
++	var skipped bool
++	defer func() { sendGeoUpdateStatus("MMDB", false, skipped, err) }()
++
+ 	vehicle := resource.NewHTTPVehicle(geodata.MmdbUrl(), C.Path.MMDB(), "", nil, defaultHttpTimeout, 0)
+ 	var oldHash utils.HashType
+ 	if buf, err := os.ReadFile(vehicle.Path()); err == nil {
+@@ -55,6 +59,7 @@ func UpdateMMDB() (err error) {
+ 		return fmt.Errorf("can't download MMDB database file: %w", err)
+ 	}
+ 	if oldHash.Equal(hash) { // same hash, ignored
++		skipped = true
+ 		return nil
+ 	}
+ 	if len(data) == 0 {
+@@ -76,6 +81,10 @@ func UpdateMMDB() (err error) {
+ }
+ 
+ func UpdateASN() (err error) {
++	sendGeoUpdateStatus("ASN", true, false, nil)
++	var skipped bool
++	defer func() { sendGeoUpdateStatus("ASN", false, skipped, err) }()
++
+ 	vehicle := resource.NewHTTPVehicle(geodata.ASNUrl(), C.Path.ASN(), "", nil, defaultHttpTimeout, 0)
+ 	var oldHash utils.HashType
+ 	if buf, err := os.ReadFile(vehicle.Path()); err == nil {
+@@ -86,6 +95,7 @@ func UpdateASN() (err error) {
+ 		return fmt.Errorf("can't download ASN database file: %w", err)
+ 	}
+ 	if oldHash.Equal(hash) { // same hash, ignored
++		skipped = true
+ 		return nil
+ 	}
+ 	if len(data) == 0 {
+@@ -107,6 +117,10 @@ func UpdateASN() (err error) {
+ }
+ 
+ func UpdateGeoIp() (err error) {
++	sendGeoUpdateStatus("GEOIP", true, false, nil)
++	var skipped bool
++	defer func() { sendGeoUpdateStatus("GEOIP", false, skipped, err) }()
++
+ 	geoLoader, err := geodata.GetGeoDataLoader("standard")
+ 
+ 	vehicle := resource.NewHTTPVehicle(geodata.GeoIpUrl(), C.Path.GeoIP(), "", nil, defaultHttpTimeout, 0)
+@@ -119,6 +133,7 @@ func UpdateGeoIp() (err error) {
+ 		return fmt.Errorf("can't download GeoIP database file: %w", err)
+ 	}
+ 	if oldHash.Equal(hash) { // same hash, ignored
++		skipped = true
+ 		return nil
+ 	}
+ 	if len(data) == 0 {
+@@ -137,6 +152,10 @@ func UpdateGeoIp() (err error) {
+ }
+ 
+ func UpdateGeoSite() (err error) {
++	sendGeoUpdateStatus("GEOSITE", true, false, nil)
++	var skipped bool
++	defer func() { sendGeoUpdateStatus("GEOSITE", false, skipped, err) }()
++
+ 	geoLoader, err := geodata.GetGeoDataLoader("standard")
+ 
+ 	vehicle := resource.NewHTTPVehicle(geodata.GeoSiteUrl(), C.Path.GeoSite(), "", nil, defaultHttpTimeout, 0)
+@@ -149,6 +168,7 @@ func UpdateGeoSite() (err error) {
+ 		return fmt.Errorf("can't download GeoSite database file: %w", err)
+ 	}
+ 	if oldHash.Equal(hash) { // same hash, ignored
++		skipped = true
+ 		return nil
+ 	}
+ 	if len(data) == 0 {
+diff --git a/config/config.go b/config/config.go
+index 45efb291e339dee50aa4c9ffd9056e7f7ff37107..babbc4c2e906b4d4e1a316456b936726cf77ea67 100644
+--- a/config/config.go
++++ b/config/config.go
+@@ -989,6 +989,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
+ 		return nil, nil, err
+ 	}
+ 
++	SetProxyNameList(proxyList)
+ 	return proxies, providersMap, nil
+ }
+ 
+diff --git a/config/patch.go b/config/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..01c415ab732bdd2b92accec1e69411a6fcf7d957
+--- /dev/null
++++ b/config/patch.go
+@@ -0,0 +1,20 @@
++package config
++
++import "sync"
++
++var (
++	proxyNameList   []string
++	proxyNameListMu sync.RWMutex
++)
++
++func GetProxyNameList() []string {
++	proxyNameListMu.RLock()
++	defer proxyNameListMu.RUnlock()
++	return proxyNameList
++}
++
++func SetProxyNameList(list []string) {
++	proxyNameListMu.Lock()
++	defer proxyNameListMu.Unlock()
++	proxyNameList = list
++}
+diff --git a/constant/adapters.go b/constant/adapters.go
+index a28ac547a7bcd287404546fd8555f8ef7c0e362c..0cf51f5fa93a1fe0e3a8967238a231f6445ffb6d 100644
+--- a/constant/adapters.go
++++ b/constant/adapters.go
+@@ -61,9 +61,10 @@ const (
+ 	DefaultUDPTimeout = dialer.DefaultUDPTimeout
+ 	DefaultDropTime   = 12 * DefaultTCPTimeout
+ 	DefaultTLSTimeout = DefaultTCPTimeout
+-	DefaultTestURL    = "https://www.gstatic.com/generate_204"
+ )
+ 
++var DefaultTestURL = "https://www.gstatic.com/generate_204"
++
+ var ErrNotSupport = errors.New("no support")
+ 
+ type Connection interface {
+diff --git a/constant/features/android.go b/constant/features/android.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..c1174f0804f63870aac82efef8432038c2e63673
+--- /dev/null
++++ b/constant/features/android.go
+@@ -0,0 +1,5 @@
++//go:build android
++
++package features
++
++const Android = true
+diff --git a/constant/features/android_stub.go b/constant/features/android_stub.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..282493e7c759f07766d541e1bd00cb9414575137
+--- /dev/null
++++ b/constant/features/android_stub.go
+@@ -0,0 +1,5 @@
++//go:build !android
++
++package features
++
++const Android = false
+diff --git a/constant/features/cmfa.go b/constant/features/cmfa.go
+deleted file mode 100644
+index 9a81d82ffe5c9e016a8aeba434e30ed6c2606250..0000000000000000000000000000000000000000
+--- a/constant/features/cmfa.go
++++ /dev/null
+@@ -1,5 +0,0 @@
+-//go:build cmfa
+-
+-package features
+-
+-const CMFA = true
+diff --git a/constant/features/cmfa_stub.go b/constant/features/cmfa_stub.go
+deleted file mode 100644
+index f7ef082741045fbabbaf5cac9cea78a94a51079e..0000000000000000000000000000000000000000
+--- a/constant/features/cmfa_stub.go
++++ /dev/null
+@@ -1,5 +0,0 @@
+-//go:build !cmfa
+-
+-package features
+-
+-const CMFA = false
+diff --git a/constant/features/tags.go b/constant/features/tags.go
+index 524c4d77e50e22b762b48ba1dc4209dc12e7025a..ac12385cc0132a1ad23a1b22d8ebb56304a3fa53 100644
+--- a/constant/features/tags.go
++++ b/constant/features/tags.go
+@@ -1,9 +1,6 @@
+ package features
+ 
+ func Tags() (tags []string) {
+-	if CMFA {
+-		tags = append(tags, "cmfa")
+-	}
+ 	if WithLowMemory {
+ 		tags = append(tags, "with_low_memory")
+ 	}
+diff --git a/constant/path.go b/constant/path.go
+index f2463a4a235e7c10f24aaeb6ebadb1430b14d245..590928d0b6cfc523da73c582dd6015f121b6781a 100644
+--- a/constant/path.go
++++ b/constant/path.go
+@@ -86,7 +86,7 @@ func (p *path) Resolve(path string) string {
+ 
+ // IsSafePath return true if path is a subpath of homedir (or in the SAFE_PATHS environment variable)
+ func (p *path) IsSafePath(path string) bool {
+-	if p.allowUnsafePath || features.CMFA {
++	if p.allowUnsafePath || features.Android {
+ 		return true
+ 	}
+ 	path = p.Resolve(path)
+@@ -135,7 +135,8 @@ func (p *path) MMDB() string {
+ 		} else {
+ 			if strings.EqualFold(fi.Name(), "Country.mmdb") ||
+ 				strings.EqualFold(fi.Name(), "geoip.db") ||
+-				strings.EqualFold(fi.Name(), "geoip.metadb") {
++				strings.EqualFold(fi.Name(), "geoip.metadb") ||
++				strings.EqualFold(fi.Name(), "GEOIP.metadb") {
+ 				GeoipName = fi.Name()
+ 				return P.Join(p.homeDir, fi.Name())
+ 			}
+@@ -200,7 +201,8 @@ func (p *path) GeoIP() string {
+ 			// 目录则直接跳过
+ 			continue
+ 		} else {
+-			if strings.EqualFold(fi.Name(), "GeoIP.dat") {
++			if strings.EqualFold(fi.Name(), "GeoIP.dat") ||
++				strings.EqualFold(fi.Name(), "GEOIP.dat") {
+ 				GeoipName = fi.Name()
+ 				return P.Join(p.homeDir, fi.Name())
+ 			}
+@@ -219,7 +221,8 @@ func (p *path) GeoSite() string {
+ 			// 目录则直接跳过
+ 			continue
+ 		} else {
+-			if strings.EqualFold(fi.Name(), "GeoSite.dat") {
++			if strings.EqualFold(fi.Name(), "GeoSite.dat") ||
++				strings.EqualFold(fi.Name(), "GEOSITE.dat") {
+ 				GeositeName = fi.Name()
+ 				return P.Join(p.homeDir, fi.Name())
+ 			}
+diff --git a/dns/patch_android.go b/dns/patch_android.go
+index cad718b6930ba627f261b51c2fcf5c43621f8ce9..138e95d57bfda8d853d9b817f3c43e56dd5e08f4 100644
+--- a/dns/patch_android.go
++++ b/dns/patch_android.go
+@@ -1,4 +1,4 @@
+-//go:build android && cmfa
++//go:build android
+ 
+ package dns
+ 
+diff --git a/dns/system_common.go b/dns/system_common.go
+index e6dabdcfff1411b8115c3f50b1fbcda5826a6ec1..78c4a86f28131474ff27801e21d1165aa18ab081 100644
+--- a/dns/system_common.go
++++ b/dns/system_common.go
+@@ -1,4 +1,4 @@
+-//go:build !(android && cmfa)
++//go:build !android
+ 
+ package dns
+ 
+diff --git a/hub/executor/executor.go b/hub/executor/executor.go
+index 796face2f1b9eb498035ce8d2cf72e62ea5a0b0c..dc7c66b9376f67135e1d33becc4b54d6bf619422 100644
+--- a/hub/executor/executor.go
++++ b/hub/executor/executor.go
+@@ -104,8 +104,8 @@ func ApplyConfig(cfg *config.Config, force bool) {
+ 	updateGeneral(cfg.General, true)
+ 	updateDNS(cfg.DNS, cfg.General.IPv6)
+ 	updateNTP(cfg.NTP) // initialize NTP after DNS because an NTP server may be a hostname.
+-	updateListeners(cfg.General, cfg.Listeners, force)
+-	updateTun(cfg.General) // tun should not care "force"
++	//updateListeners(cfg.General, cfg.Listeners, force)
++	//updateTun(cfg.General) // tun should not care "force"
+ 	updateIPTables(cfg)
+ 	updateTunnels(cfg.Tunnels)
+ 
+@@ -328,13 +328,17 @@ func loadProvider[T P.Provider](providers map[string]T) {
+ 			switch pv.Type() {
+ 			case P.Proxy:
+ 				{
+-					log.Errorln("initial proxy provider %s error: %v", name, err)
++					log.Warnln("initial proxy provider %s error: %v", name, err)
+ 				}
+ 			case P.Rule:
+ 				{
+-					log.Errorln("initial rule provider %s error: %v", name, err)
++					log.Warnln("initial rule provider %s error: %v", name, err)
+ 				}
+ 			}
++		} else {
++			if DefaultProviderLoadedHook != nil {
++				DefaultProviderLoadedHook(name)
++			}
+ 		}
+ 	}
+ 
+@@ -349,7 +353,6 @@ func loadProvider[T P.Provider](providers map[string]T) {
+ 			load(pv)
+ 		}()
+ 	}
+-	wg.Wait()
+ }
+ 
+ func updateSniffer(snifferConfig *sniffer.Config) {
+diff --git a/hub/executor/patch.go b/hub/executor/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..1cbbbbc0c0a06cad673a607d1ffb8ed06f6dfc4c
+--- /dev/null
++++ b/hub/executor/patch.go
+@@ -0,0 +1,5 @@
++package executor
++
++type ProviderLoadedHook func(providerName string)
++
++var DefaultProviderLoadedHook ProviderLoadedHook
+diff --git a/hub/route/patch_android.go b/hub/route/patch_android.go
+index 5eba2796467ff3bb339f16618de057394b5f0f97..4b6dcf25acb9bf0983b0b89973ca0497bc359360 100644
+--- a/hub/route/patch_android.go
++++ b/hub/route/patch_android.go
+@@ -1,4 +1,4 @@
+-//go:build android && cmfa
++//go:build android
+ 
+ package route
+ 
+diff --git a/hub/route/server.go b/hub/route/server.go
+index 6d37d4802bfe4e5caef8fc224479a1225c38ab8e..b1659cd085d278193a94ed860e3bfd9a8721d95e 100644
+--- a/hub/route/server.go
++++ b/hub/route/server.go
+@@ -181,9 +181,7 @@ func start(cfg *Config) {
+ 			Handler: router(cfg.IsDebug, cfg.Secret, cfg.DohServer, cfg.Cors),
+ 		}
+ 		httpServer = server
+-		if err = server.Serve(l); err != nil {
+-			log.Errorln("External controller serve error: %s", err)
+-		}
++		_ = server.Serve(l)
+ 	}
+ }
+ 
+diff --git a/listener/http/patch_android.go b/listener/http/patch_android.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..a763c95e853b15d73008bdbeb2bb253beef7cf03
+--- /dev/null
++++ b/listener/http/patch_android.go
+@@ -0,0 +1,9 @@
++//go:build android
++
++package http
++
++import "net"
++
++func (l *Listener) Listener() net.Listener {
++	return l.listener
++}
+diff --git a/listener/listener.go b/listener/listener.go
+index 3a0a8aad415dc078529a86417048522796fd2a3d..ececbc41fd6bf11788a88b30399e0c0fbc75ec03 100644
+--- a/listener/listener.go
++++ b/listener/listener.go
+@@ -512,10 +512,8 @@ func ReCreateTun(tunConf LC.Tun, tunnel C.Tunnel) {
+ 		}
+ 	}()
+ 
+-	if tunConf.Equal(LastTunConf) {
+-		if tunLister != nil { // some default value in dialer maybe changed when config reload, reset at here
+-			tunLister.OnReload()
+-		}
++	if tunLister != nil && tunConf.Equal(LastTunConf) {
++		tunLister.OnReload()
+ 		return
+ 	}
+ 
+diff --git a/listener/patch.go b/listener/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ab5aa1182cb5c87f6716b754c7981286c9e7c04
+--- /dev/null
++++ b/listener/patch.go
+@@ -0,0 +1,74 @@
++package listener
++
++func StopListener() {
++
++	if socksListener != nil {
++		_ = socksListener.Close()
++		socksListener = nil
++	}
++
++	if socksUDPListener != nil {
++		_ = socksUDPListener.Close()
++		socksUDPListener = nil
++	}
++
++	if httpListener != nil {
++		_ = httpListener.Close()
++		httpListener = nil
++	}
++
++	if redirListener != nil {
++		_ = redirListener.Close()
++		redirListener = nil
++	}
++
++	if redirUDPListener != nil {
++		_ = redirUDPListener.Close()
++		redirUDPListener = nil
++	}
++
++	if tproxyListener != nil {
++		_ = tproxyListener.Close()
++		tproxyListener = nil
++	}
++
++	if tproxyUDPListener != nil {
++		_ = tproxyUDPListener.Close()
++		tproxyUDPListener = nil
++	}
++
++	if mixedListener != nil {
++		_ = mixedListener.Close()
++		mixedListener = nil
++	}
++
++	if mixedUDPLister != nil {
++		_ = mixedUDPLister.Close()
++		mixedUDPLister = nil
++	}
++
++	if tunLister != nil {
++		_ = tunLister.Close()
++		tunLister = nil
++	}
++
++	if shadowSocksListener != nil {
++		_ = shadowSocksListener.Close()
++		shadowSocksListener = nil
++	}
++
++	if shadowSocksListener != nil {
++		_ = shadowSocksListener.Close()
++		shadowSocksListener = nil
++	}
++
++	if vmessListener != nil {
++		_ = vmessListener.Close()
++		vmessListener = nil
++	}
++
++	if tuicListener != nil {
++		_ = tuicListener.Close()
++		tuicListener = nil
++	}
++}
+diff --git a/listener/sing_tun/server.go b/listener/sing_tun/server.go
+index 3e5ef59197e456f4273b31da62fa7244ca437ee8..281f6348665095f8f24f1897a8b4dc5149b29bfe 100644
+--- a/listener/sing_tun/server.go
++++ b/listener/sing_tun/server.go
+@@ -469,12 +469,6 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
+ 		}
+ 
+ 	}
+-
+-	err = l.buildAndroidRules(&tunOptions)
+-	if err != nil {
+-		err = E.Cause(err, "build android rules")
+-		return
+-	}
+ 	tunIf, err := tunNew(tunOptions)
+ 	if err != nil {
+ 		err = E.Cause(err, "configure tun interface")
+diff --git a/listener/sing_tun/server_android.go b/listener/sing_tun/server_android.go
+index f180bd3051b96bec9e241468fca3388b56aa6c20..71ac263590efb8a8eafbe22ab85d45bc138ac864 100644
+--- a/listener/sing_tun/server_android.go
++++ b/listener/sing_tun/server_android.go
+@@ -1,77 +1,11 @@
+-//go:build android && !cmfa
++//go:build android
+ 
+ package sing_tun
+ 
+ import (
+-	"errors"
+-	"sync"
+-
+-	"github.com/metacubex/mihomo/component/process"
+-	"github.com/metacubex/mihomo/constant"
+-	"github.com/metacubex/mihomo/constant/features"
+-	"github.com/metacubex/mihomo/log"
+-
+-	"github.com/metacubex/sing-tun"
+-)
+-
+-type packageManagerCallback struct{}
+-
+-func (cb *packageManagerCallback) OnPackagesUpdated(packageCount int, sharedCount int) {}
+-
+-func newPackageManager() (tun.PackageManager, error) {
+-	packageManager, err := tun.NewPackageManager(tun.PackageManagerOptions{
+-		Callback: &packageManagerCallback{},
+-		Logger:   log.SingLogger,
+-	})
+-	if err != nil {
+-		return nil, err
+-	}
+-	err = packageManager.Start()
+-	if err != nil {
+-		return nil, err
+-	}
+-	return packageManager, nil
+-}
+-
+-var (
+-	globalPM tun.PackageManager
+-	pmOnce   sync.Once
+-	pmErr    error
++	tun "github.com/metacubex/sing-tun"
+ )
+ 
+-func getPackageManager() (tun.PackageManager, error) {
+-	pmOnce.Do(func() {
+-		globalPM, pmErr = newPackageManager()
+-	})
+-	return globalPM, pmErr
+-}
+-
+ func (l *Listener) buildAndroidRules(tunOptions *tun.Options) error {
+-	packageManager, err := getPackageManager()
+-	if err != nil {
+-		return err
+-	}
+-	tunOptions.BuildAndroidRules(packageManager, l.handler)
+ 	return nil
+ }
+-
+-func findPackageName(metadata *constant.Metadata) (string, error) {
+-	packageManager, err := getPackageManager()
+-	if err != nil {
+-		return "", err
+-	}
+-	uid := metadata.Uid
+-	if sharedPackage, loaded := packageManager.SharedPackageByID(uid % 100000); loaded {
+-		return sharedPackage, nil
+-	}
+-	if packageName, loaded := packageManager.PackageByID(uid % 100000); loaded {
+-		return packageName, nil
+-	}
+-	return "", errors.New("package not found")
+-}
+-
+-func init() {
+-	if !features.CMFA {
+-		process.DefaultPackageNameResolver = findPackageName
+-	}
+-}
+diff --git a/listener/sing_tun/server_notandroid.go b/listener/sing_tun/server_notandroid.go
+deleted file mode 100644
+index e393d4ca0dacfaa371e6d5bad654009493009716..0000000000000000000000000000000000000000
+--- a/listener/sing_tun/server_notandroid.go
++++ /dev/null
+@@ -1,11 +0,0 @@
+-//go:build !android || cmfa
+-
+-package sing_tun
+-
+-import (
+-	tun "github.com/metacubex/sing-tun"
+-)
+-
+-func (l *Listener) buildAndroidRules(tunOptions *tun.Options) error {
+-	return nil
+-}
+diff --git a/rules/provider/patch_android.go b/rules/provider/patch_android.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..a45b9c52c6d0495c203a8147d544e3701fb1c37a
+--- /dev/null
++++ b/rules/provider/patch_android.go
+@@ -0,0 +1,17 @@
++//go:build android
++
++package provider
++
++import "time"
++
++var (
++	suspended bool
++)
++
++type UpdatableProvider interface {
++	UpdatedAt() time.Time
++}
++
++func Suspend(s bool) {
++	suspended = s
++}
+diff --git a/tunnel/patch.go b/tunnel/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d27020cb600a893cfb6592a4129736ea0263a46
+--- /dev/null
++++ b/tunnel/patch.go
+@@ -0,0 +1,43 @@
++package tunnel
++
++import (
++	C "github.com/metacubex/mihomo/constant"
++	P "github.com/metacubex/mihomo/constant/provider"
++)
++
++var (
++	allProxies = make(map[string]C.Proxy)
++)
++
++func AllProxies() map[string]C.Proxy {
++	return proxiesWithProviders()
++}
++
++// UpdateAllProxies The provider requires runtime sync
++func UpdateAllProxies(proxies map[string]C.Proxy, providers map[string]P.ProxyProvider) {
++	var allProxiesTemp = make(map[string]C.Proxy)
++	for name, proxy := range proxies {
++		allProxiesTemp[name] = proxy
++	}
++	for _, p := range providers {
++		for _, proxy := range p.Proxies() {
++			name := proxy.Name()
++			allProxiesTemp[name] = proxy
++		}
++	}
++	allProxies = allProxiesTemp
++}
++
++func proxiesWithProviders() map[string]C.Proxy {
++	ap := make(map[string]C.Proxy)
++	for name, proxy := range Proxies() {
++		ap[name] = proxy
++	}
++	for _, p := range Providers() {
++		for _, proxy := range p.Proxies() {
++			name := proxy.Name()
++			ap[name] = proxy
++		}
++	}
++	return ap
++}
+diff --git a/tunnel/statistic/manager.go b/tunnel/statistic/manager.go
+index c69746dbcbac1d8fb1cc7f22e7bd538a3e62385c..f38ed07676f02b6e6b383ea1192605ec2f7865fc 100644
+--- a/tunnel/statistic/manager.go
++++ b/tunnel/statistic/manager.go
+@@ -26,18 +26,27 @@ func init() {
+ }
+ 
+ type Manager struct {
+-	connections   xsync.Map[string, Tracker]
+-	uploadTemp    atomic.Int64
+-	downloadTemp  atomic.Int64
+-	uploadBlip    atomic.Int64
+-	downloadBlip  atomic.Int64
+-	uploadTotal   atomic.Int64
+-	downloadTotal atomic.Int64
+-	pid           int32
+-	memory        uint64
++	connections        xsync.Map[string, Tracker]
++	uploadTemp         atomic.Int64
++	downloadTemp       atomic.Int64
++	uploadBlip         atomic.Int64
++	downloadBlip       atomic.Int64
++	uploadTotal        atomic.Int64
++	downloadTotal      atomic.Int64
++	proxyUploadTemp    atomic.Int64
++	proxyDownloadTemp  atomic.Int64
++	proxyUploadBlip    atomic.Int64
++	proxyDownloadBlip  atomic.Int64
++	proxyUploadTotal   atomic.Int64
++	proxyDownloadTotal atomic.Int64
++	pid                int32
++	memory             uint64
+ }
+ 
+ func (m *Manager) Join(c Tracker) {
++	if DefaultRequestNotify != nil {
++		DefaultRequestNotify(c)
++	}
+ 	m.connections.Store(c.ID(), c)
+ }
+ 
+@@ -58,12 +67,20 @@ func (m *Manager) Range(f func(c Tracker) bool) {
+ 	})
+ }
+ 
+-func (m *Manager) PushUploaded(size int64) {
++func (m *Manager) PushUploaded(lastChain string, size int64) {
++	if lastChain != "DIRECT" {
++		m.proxyUploadTemp.Add(size)
++		m.proxyUploadTotal.Add(size)
++	}
+ 	m.uploadTemp.Add(size)
+ 	m.uploadTotal.Add(size)
+ }
+ 
+-func (m *Manager) PushDownloaded(size int64) {
++func (m *Manager) PushDownloaded(lastChain string, size int64) {
++	if lastChain != "DIRECT" {
++		m.proxyDownloadTemp.Add(size)
++		m.proxyDownloadTotal.Add(size)
++	}
+ 	m.downloadTemp.Add(size)
+ 	m.downloadTotal.Add(size)
+ }
+@@ -110,6 +127,14 @@ func (m *Manager) ResetStatistic() {
+ 	m.downloadTemp.Store(0)
+ 	m.downloadBlip.Store(0)
+ 	m.downloadTotal.Store(0)
++
++	m.proxyUploadTemp.Store(0)
++	m.proxyUploadBlip.Store(0)
++	m.proxyUploadTotal.Store(0)
++	m.proxyDownloadTemp.Store(0)
++	m.proxyDownloadBlip.Store(0)
++	m.proxyDownloadTotal.Store(0)
++
+ }
+ 
+ func (m *Manager) handle() {
+@@ -118,6 +143,8 @@ func (m *Manager) handle() {
+ 	for range ticker.C {
+ 		m.uploadBlip.Store(m.uploadTemp.Swap(0))
+ 		m.downloadBlip.Store(m.downloadTemp.Swap(0))
++		m.proxyUploadBlip.Store(m.proxyUploadTemp.Swap(0))
++		m.proxyDownloadBlip.Store(m.proxyDownloadTemp.Swap(0))
+ 	}
+ }
+ 
+diff --git a/tunnel/statistic/patch.go b/tunnel/statistic/patch.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..3f170ee8731139b0aa5fa66294cad34a9b6bf1c6
+--- /dev/null
++++ b/tunnel/statistic/patch.go
+@@ -0,0 +1,19 @@
++package statistic
++
++type RequestNotify func(c Tracker)
++
++var DefaultRequestNotify RequestNotify
++
++func (m *Manager) TotalTraffic(onlyProxy bool) (up, down int64) {
++	if onlyProxy {
++		return m.proxyUploadTotal.Load(), m.proxyDownloadTotal.Load()
++	}
++	return m.uploadTotal.Load(), m.downloadTotal.Load()
++}
++
++func (m *Manager) NowTraffic(onlyProxy bool) (up, down int64) {
++	if onlyProxy {
++		return m.proxyUploadBlip.Load(), m.proxyDownloadBlip.Load()
++	}
++	return m.uploadBlip.Load(), m.downloadBlip.Load()
++}
+diff --git a/tunnel/statistic/patch_android.go b/tunnel/statistic/patch_android.go
+new file mode 100644
+index 0000000000000000000000000000000000000000..1c4b43b05965b129a86e9f2223c445c723e4c642
+--- /dev/null
++++ b/tunnel/statistic/patch_android.go
+@@ -0,0 +1,3 @@
++//go:build android
++
++package statistic
+diff --git a/tunnel/statistic/tracker.go b/tunnel/statistic/tracker.go
+index 2fbb1cf9e350605e47c2ebf478ac6ab0f4ebf472..fa9860a04c2dc4bb37ba791569d86c56583a11d7 100644
+--- a/tunnel/statistic/tracker.go
++++ b/tunnel/statistic/tracker.go
+@@ -53,7 +53,7 @@ func (tt *tcpTracker) Read(b []byte) (int, error) {
+ 	n, err := tt.Conn.Read(b)
+ 	download := int64(n)
+ 	if tt.pushToManager {
+-		tt.manager.PushDownloaded(download)
++		tt.manager.PushDownloaded(tt.Conn.Chains().Last(), download)
+ 	}
+ 	tt.DownloadTotal.Add(download)
+ 	return n, err
+@@ -63,7 +63,7 @@ func (tt *tcpTracker) ReadBuffer(buffer *buf.Buffer) (err error) {
+ 	err = tt.Conn.ReadBuffer(buffer)
+ 	download := int64(buffer.Len())
+ 	if tt.pushToManager {
+-		tt.manager.PushDownloaded(download)
++		tt.manager.PushDownloaded(tt.Chains().Last(), download)
+ 	}
+ 	tt.DownloadTotal.Add(download)
+ 	return
+@@ -72,7 +72,7 @@ func (tt *tcpTracker) ReadBuffer(buffer *buf.Buffer) (err error) {
+ func (tt *tcpTracker) UnwrapReader() (io.Reader, []N.CountFunc) {
+ 	return tt.Conn, []N.CountFunc{func(download int64) {
+ 		if tt.pushToManager {
+-			tt.manager.PushDownloaded(download)
++			tt.manager.PushDownloaded(tt.Chains().Last(), download)
+ 		}
+ 		tt.DownloadTotal.Add(download)
+ 	}}
+@@ -82,7 +82,7 @@ func (tt *tcpTracker) Write(b []byte) (int, error) {
+ 	n, err := tt.Conn.Write(b)
+ 	upload := int64(n)
+ 	if tt.pushToManager {
+-		tt.manager.PushUploaded(upload)
++		tt.manager.PushUploaded(tt.Chains().Last(), upload)
+ 	}
+ 	tt.UploadTotal.Add(upload)
+ 	return n, err
+@@ -92,7 +92,7 @@ func (tt *tcpTracker) WriteBuffer(buffer *buf.Buffer) (err error) {
+ 	upload := int64(buffer.Len())
+ 	err = tt.Conn.WriteBuffer(buffer)
+ 	if tt.pushToManager {
+-		tt.manager.PushUploaded(upload)
++		tt.manager.PushUploaded(tt.Chains().Last(), upload)
+ 	}
+ 	tt.UploadTotal.Add(upload)
+ 	return
+@@ -101,7 +101,7 @@ func (tt *tcpTracker) WriteBuffer(buffer *buf.Buffer) (err error) {
+ func (tt *tcpTracker) UnwrapWriter() (io.Writer, []N.CountFunc) {
+ 	return tt.Conn, []N.CountFunc{func(upload int64) {
+ 		if tt.pushToManager {
+-			tt.manager.PushUploaded(upload)
++			tt.manager.PushUploaded(tt.Chains().Last(), upload)
+ 		}
+ 		tt.UploadTotal.Add(upload)
+ 	}}
+@@ -119,7 +119,7 @@ func (tt *tcpTracker) Upstream() any {
+ func NewTCPTracker(conn C.Conn, manager *Manager, metadata *C.Metadata, rule C.Rule, uploadTotal int64, downloadTotal int64, pushToManager bool) *tcpTracker {
+ 	metadata.RemoteDst = conn.RemoteDestination()
+ 
+-	t := &tcpTracker{
++	tt := &tcpTracker{
+ 		Conn:    conn,
+ 		manager: manager,
+ 		TrackerInfo: &TrackerInfo{
+@@ -137,20 +137,20 @@ func NewTCPTracker(conn C.Conn, manager *Manager, metadata *C.Metadata, rule C.R
+ 
+ 	if pushToManager {
+ 		if uploadTotal > 0 {
+-			manager.PushUploaded(uploadTotal)
++			manager.PushUploaded(tt.Chains().Last(), uploadTotal)
+ 		}
+ 		if downloadTotal > 0 {
+-			manager.PushDownloaded(downloadTotal)
++			manager.PushDownloaded(tt.Chains().Last(), downloadTotal)
+ 		}
+ 	}
+ 
+ 	if rule != nil {
+-		t.TrackerInfo.Rule = rule.RuleType().String()
+-		t.TrackerInfo.RulePayload = rule.Payload()
++		tt.TrackerInfo.Rule = rule.RuleType().String()
++		tt.TrackerInfo.RulePayload = rule.Payload()
+ 	}
+ 
+-	manager.Join(t)
+-	return t
++	manager.Join(tt)
++	return tt
+ }
+ 
+ type udpTracker struct {
+@@ -173,7 +173,7 @@ func (ut *udpTracker) ReadFrom(b []byte) (int, net.Addr, error) {
+ 	n, addr, err := ut.PacketConn.ReadFrom(b)
+ 	download := int64(n)
+ 	if ut.pushToManager {
+-		ut.manager.PushDownloaded(download)
++		ut.manager.PushDownloaded(ut.Chains().Last(), download)
+ 	}
+ 	ut.DownloadTotal.Add(download)
+ 	return n, addr, err
+@@ -183,7 +183,7 @@ func (ut *udpTracker) WaitReadFrom() (data []byte, put func(), addr net.Addr, er
+ 	data, put, addr, err = ut.PacketConn.WaitReadFrom()
+ 	download := int64(len(data))
+ 	if ut.pushToManager {
+-		ut.manager.PushDownloaded(download)
++		ut.manager.PushDownloaded(ut.Chains().Last(), download)
+ 	}
+ 	ut.DownloadTotal.Add(download)
+ 	return
+@@ -193,7 +193,7 @@ func (ut *udpTracker) WriteTo(b []byte, addr net.Addr) (int, error) {
+ 	n, err := ut.PacketConn.WriteTo(b, addr)
+ 	upload := int64(n)
+ 	if ut.pushToManager {
+-		ut.manager.PushUploaded(upload)
++		ut.manager.PushUploaded(ut.Chains().Last(), upload)
+ 	}
+ 	ut.UploadTotal.Add(upload)
+ 	return n, err
+@@ -229,10 +229,10 @@ func NewUDPTracker(conn C.PacketConn, manager *Manager, metadata *C.Metadata, ru
+ 
+ 	if pushToManager {
+ 		if uploadTotal > 0 {
+-			manager.PushUploaded(uploadTotal)
++			manager.PushUploaded(ut.Chains().Last(), uploadTotal)
+ 		}
+ 		if downloadTotal > 0 {
+-			manager.PushDownloaded(downloadTotal)
++			manager.PushDownloaded(ut.Chains().Last(), downloadTotal)
+ 		}
+ 	}
+ 
+diff --git a/tunnel/tunnel.go b/tunnel/tunnel.go
+index 86dbc14ae428ba7927dd2dc3ab52d78f0ddb1e87..be215f562b2e71e7ba8eafc5b5e57fd2839dfa43 100644
+--- a/tunnel/tunnel.go
++++ b/tunnel/tunnel.go
+@@ -231,6 +231,7 @@ func UpdateProxies(newProxies map[string]C.Proxy, newProviders map[string]P.Prox
+ 	configMux.Lock()
+ 	proxies = newProxies
+ 	providers = newProviders
++	UpdateAllProxies(newProxies, newProviders)
+ 	configMux.Unlock()
+ }
+ 
+@@ -351,7 +352,7 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
+ 		FindProcess: func() {
+ 			if attemptProcessLookup {
+ 				attemptProcessLookup = false
+-				if !features.CMFA {
++				if !features.Android {
+ 					// normal check for process
+ 					uid, path, err := process.FindProcessName(metadata.NetWork.String(), metadata.SrcIP, int(metadata.SrcPort))
+ 					if err != nil {

--- a/secrets.properties.example
+++ b/secrets.properties.example
@@ -8,6 +8,8 @@
 # The equivalent environment variables take precedence and are what CI should use:
 #   WHITEDNS_MIHOMO_SUBSCRIPTION_KEY
 #   WHITEDNS_ENCRYPTED_IP_LIST_KEY
+#   WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL
 
 mihomoSubscriptionKey=change-me
 encryptedIpListKey=change-me
+privateMihomoSubscriptionUrl=https://example.com/private-subscription


### PR DESCRIPTION
## Title

Release WhiteVPN v1.6.6

## Description

WhiteVPN 1.6.6 adds a required build-injected Private subscription. Automatic connections try Private first, then Public if Private cannot establish a healthy runtime connection. Public fallback does not change the saved preference and displays a persistent Home notice and ongoing notification.

The release also adds AnyTLS share-link import and updates the bundled Mihomo core to v1.19.30 with AmneziaWG v3 support.

### Changes

- Add `WHITEDNS_PRIVATE_MIHOMO_SUBSCRIPTION_URL` GitHub Actions secret.
- Require an HTTPS Private URL during builds.
- Fetch Private when the app loads.
- Keep isolated Private and Public caches.
- Retry Private first during startup, reconnect, and recovery.
- Preserve explicit selections, chains, filters, and custom subscriptions.
- Track the actual runtime subscription through delays, pruning, and recovery.
- Show `WhiteVPN اختصاصی` and `WhiteVPN عمومی`.
- Warn while connected through Public servers.
- Add AnyTLS import with certificate verification enforced.
- Update Mihomo to v1.19.30 with AmneziaWG v3 compatibility patches.

### Validation

- Unit tests passed.
- Debug build passed.
- Subscription cache and settings-reset instrumented tests passed.
- Emulator verified Private success and Private failure → Public success.
- Verified Public notice after reopening and with notification permission denied.
- Verified returning to Private clears the Public notice.